### PR TITLE
[Unzip] remove IO for Open3

### DIFF
--- a/app/interactors/download_file.rb
+++ b/app/interactors/download_file.rb
@@ -5,7 +5,6 @@ class DownloadFile < SireneAsAPIInteractor
     stdout_info_log "Attempting to download #{filename}"
 
     context.filepath = "./tmp/files/#{filename}"
-    context.filename = filename
 
     if File.exist?(context.filepath)
       stdout_warn_log "#{filename} already exists ! Skipping download"

--- a/spec/interactors/unzip_file_spec.rb
+++ b/spec/interactors/unzip_file_spec.rb
@@ -1,25 +1,27 @@
 require 'rails_helper'
-require 'spec_helper'
 
 describe UnzipFile do
-  patch_filepath = 'spec/fixtures/sample_patches/geo-sirene_2017024_E_Q.csv.gz'
-  patch_filename = 'geo-sirene_2017024_E_Q_2017_02.csv'
-  expected_unzipped_file_path = "tmp/files/#{patch_filename}"
+  let(:patch_filename) { 'geo-sirene_2017024_E_Q.csv' }
+  let(:patch_filepath) { "spec/fixtures/sample_patches/#{patch_filename}.gz" }
+  let(:expected_unzipped_file_path) { "spec/fixtures/sample_patches/#{patch_filename}" }
 
-  subject(:context) { UnzipFile.call(filepath: patch_filepath, filename: patch_filename) }
+  subject(:context) { described_class.call filepath: patch_filepath }
+
+  after do
+    File.delete(expected_unzipped_file_path) if File.exist?(expected_unzipped_file_path)
+  end
 
   context 'when called & The file is already there' do
-    before do
-      File.new(expected_unzipped_file_path, 'w')
-    end
-    
+    before { File.new(expected_unzipped_file_path, 'w') }
+
     it 'pass the adress in context' do
-      expect(context.unzipped_files).to eq(["tmp/files/#{patch_filename}"])
+      expect(context.unzipped_files).to eq([expected_unzipped_file_path])
     end
-    it 'doesnt write to a new file' do
-      expect(File).not_to receive(:open)
-      expect(IO).not_to receive(:copy_stream)
-      UnzipFile.call(filepath: patch_filepath, filename: patch_filename)
+
+    it 'doesnt unzip the file' do
+      expect(Open3).not_to receive(:capture3)
+      expect_any_instance_of(described_class).to receive(:stdout_warn_log).with(/Skipping unzip of file/)
+      context
     end
   end
 
@@ -27,14 +29,35 @@ describe UnzipFile do
     before do
       File.delete(expected_unzipped_file_path) if File.exist?(expected_unzipped_file_path)
     end
-    
-    it 'pass the adress in context' do
+
+    it 'passes the adress in context' do
       expect(context.unzipped_files).to eq([expected_unzipped_file_path])
     end
-    it 'create a new file and write inside' do
-      expect(IO).to receive(:copy_stream)
-      UnzipFile.call(filepath: patch_filepath, filename: patch_filename)
-      expect(File.exist?(expected_unzipped_file_path)).to be_truthy
+
+    it 'unzip the file' do
+      expect(Open3).to receive(:capture3).and_call_original
+      context
+      expect(File).to exist(expected_unzipped_file_path)
+    end
+
+    context 'when gunzip fails' do
+      let(:patch_filepath) { 'tmp/fake_gzip.csv.gz' }
+
+      before { File.new(patch_filepath, 'w') }
+
+      it 'does not pass the adress in context' do
+        expect(context.unzipped_files).to be_empty
+      end
+
+      it 'does not write to a new file' do
+        context
+        expect(File).not_to exist('tmp/fake_gzip.csv')
+      end
+
+      it 'logs an error' do
+        expect_any_instance_of(described_class).to receive(:stdout_error_log).with(/Failed to unzip file \(error:/)
+        context
+      end
     end
   end
 end


### PR DESCRIPTION
  `IO.copy_stream` was unzip only headers
  for unknown reason on some files
  Open3 is more complex but return at least stderr

Testé en local import des données en cours (`sirene_as_api:populate_database`)