### PR TITLE
Sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'interactor-rails', '~> 2.0'
 # Gem for deploying cron jobs
 gem 'whenever', require: false
 
+gem 'sitemap_generator'
+
 group :development, :test do
   gem 'byebug', platform: :mri
   gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,8 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.2)
       tilt (~> 2.0)
+    sitemap_generator (6.0.2)
+      builder (~> 3.0)
     smarter_csv (1.2.3)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -348,6 +350,7 @@ DEPENDENCIES
   simplecov
   simplecov-console
   sinatra (~> 2.0.2)
+  sitemap_generator
   smarter_csv
   spring
   spring-commands-rspec

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -25,4 +25,8 @@ if environment == 'production'
   every 1.day, at: '4:30 am' do
     rake 'sirene_as_api:dual_server_update'
   end
+
+  every :weekend, at: '1:00 am' do
+    rake "-s sitemap:refresh:no_ping"
+  end
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,0 +1,31 @@
+SitemapGenerator::Sitemap.default_host = "http://entreprise.data.gouv.fr"
+
+SitemapGenerator::Sitemap.create do
+  # https://github.com/kjvarga/sitemap_generator
+  # Put links creation logic here.
+  #
+  # The root path '/' and sitemap index file are added automatically for you.
+  # Links are added to the Sitemap in the order they are specified.
+  #
+  # Usage: add(path, options={})
+  #        (default options are used if you don't specify)
+  #
+  # Defaults: :priority => 0.5, :changefreq => 'weekly',
+  #           :lastmod => Time.now, :host => default_host
+  #
+  # Examples:
+  #
+  # Add '/articles'
+  #   add articles_path, :priority => 0.7, :changefreq => 'daily'
+  #
+  # Add all articles:
+  #   Article.find_each do |article|
+  #     add article_path(article), :lastmod => article.updated_at
+  #   end
+
+  Etablissement.find_each do |etab|
+    add "/etablissement/#{etab.siret}",
+      lastmod: etab.updated_at,
+      changefreq: 'monthly'
+  end
+end


### PR DESCRIPTION
- mise à jour de la sitemap une fois par mois
- indique aux bot que les données sont mises à jours mensuellement
- et on ne ping pas les bots (pour le moment)

cf Issue sur le ban des Bots: https://github.com/etalab/entreprise.data.gouv.fr/issues/287
-> cf tenue de charge #163 
cf PR côté front: https://github.com/etalab/entreprise.data.gouv.fr/pull/288