### PR TITLE
Ajout de etablissement_siege au serializer unite_legale

### DIFF
--- a/app/serializers/api/v3/unite_legale_serializer.rb
+++ b/app/serializers/api/v3/unite_legale_serializer.rb
@@ -4,4 +4,10 @@ class API::V3::UniteLegaleSerializer < ApplicationSerializer
   attributes *all_fields
 
   has_many :etablissements
+
+  attribute :etablissement_siege
+
+  def etablissement_siege
+    object.etablissements.where(etablissement_siege: 'true').first
+  end
 end

--- a/spec/controllers/api/v3/etablissements_controller_spec.rb
+++ b/spec/controllers/api/v3/etablissements_controller_spec.rb
@@ -17,7 +17,7 @@ describe API::V3::EtablissementsController do
 
     it 'returns his parent unite_legale' do
       # Parsing as json to replicate serializer formatting for timestamps
-      expect(results[0]['unite_legale']).to eq(JSON.parse unite_legale.to_json)
+      expect(results[0]['unite_legale']).to include(JSON.parse unite_legale.to_json)
     end
   end
 end

--- a/spec/controllers/api/v3/unites_legales_controller_spec.rb
+++ b/spec/controllers/api/v3/unites_legales_controller_spec.rb
@@ -9,8 +9,8 @@ describe API::V3::UnitesLegalesController do
 
   describe 'associations', type: :request do
     let!(:unite_legale)    { create(:unite_legale) }
-    let!(:etablissement_1) { create(:etablissement, unite_legale: unite_legale) }
-    let!(:etablissement_2) { create(:etablissement, unite_legale: unite_legale) }
+    let!(:etablissement_1) { create(:etablissement, unite_legale: unite_legale, etablissement_siege: 'true') }
+    let!(:etablissement_2) { create(:etablissement, unite_legale: unite_legale, etablissement_siege: 'false') }
 
     let(:results) { response.parsed_body['unites_legales'] }
 
@@ -24,6 +24,10 @@ describe API::V3::UnitesLegalesController do
 
     it 'returns its two children etablissements' do
       expect(results[0]['etablissements']).to contain_exactly(children_1, children_2)
+    end
+
+    it 'returns the siege etablissement' do
+      expect(results[0]['etablissement_siege']).to eq(children_1)
     end
   end
 end

--- a/spec/factories/unite_legale_factory.rb
+++ b/spec/factories/unite_legale_factory.rb
@@ -5,7 +5,8 @@ FactoryBot.define do
 
     factory :unite_legale_with_2_etablissements do
       after(:create) do |unite_legale|
-        create_list(:etablissement, 2, unite_legale: unite_legale)
+        create(:etablissement, unite_legale: unite_legale, etablissement_siege: 'true')
+        create(:etablissement, unite_legale: unite_legale, etablissement_siege: 'false')
       end
     end
   end


### PR DESCRIPTION
Dans l'esprit de déplacer la logique du front vers l'API, renvoyer l'établissement siège d'une unité légale dans la réponse me parait important.