### PR TITLE
Fix deployment error

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -75,7 +75,6 @@ task deploy: :remote_environment do
     # instance of your project.
     invoke :'git:clone'
     invoke :'deploy:link_shared_paths'
-    set :bundle_options, fetch(:bundle_options) + ' --clean'
     invoke :'bundle:install'
     invoke :'rails:db_migrate'
 
@@ -98,8 +97,6 @@ end
 task whenever_update: :remote_environment do
   # default value is based on domain name, and it is used to match in crontab !
   set :whenever_name, "sirene_api_#{ENV['to']}"
-  # with our rbenv config it cannot be found...
-  set :bundle_bin, '/usr/local/rbenv/shims/bundle'
 
   # whenever environement comes from fetch(:rails_env)
   invoke :'whenever:update'


### PR DESCRIPTION
### Pourquoi cette PR ?
Lors du dernier déploiement une erreur est apparue (pourquoi ça fonctionnait avant je ne sais pas).
Lors du `bundle install` il y avait l'options `--clean`. Cette option supprime toutes les gems non référencées dans le Gemfile.lock, et apparemment cette tâche est bugguée.
Elle supprimait la gem `SmarterCSV` ; le bug n'est **que** sur les gems installée avec l'option GitProxy (`gem 'bidule', git: 'https:///...'`)

### Solution
En attendant que bundler fixe ce problème on vire l'option `--clean`

### Pourquoi il y avait --clean ?
En production les gems sont installées dans `/vendor` et si on installe une gem et qu'ensuite on la vire **elle reste** dans `/vendor` par défaut.
Ceci est un problème pour au moins ces deux raison : 
1. une gem inutilisée où une faille de sécu a été détectée on ne **sait même pas** qu'elle est installée en prod...
2. _la raison_ pour laquelle j'avais mis l'option c'est que j'avais trouvée une gem du groupe "developpment" installée sur les serveurs dans `/vendor` ; j'imagine quelqu'un qui a fait un `bundle install` manuel pour corriger un problème sauf que la gem est restée des mois je pense... une gem de dev en prod, c'est non ! que ça arrive l'erreur est humaine, mais l'option `--clean` corrige le soucis au prochain déploiement plutôt que de ne jamais le savoir !

### La suite
L'issue est déjà connue et sera fixée dans Bundler 2.1.0 (actuellement en pre-release)
mon issue inutile... https://github.com/bundler/bundler/issues/7378