### PR TITLE
Added more fields to index during import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 ---
 language: ruby
-rbenv:
-  - 1.1.1
 cache: bundler
 jdk:
   - openjdk8
@@ -10,7 +8,6 @@ addons:
   env:
     matrix:
       - DB=postgresql
-      - secure: 'symtwtFAhzoi2x0G/77b2lUB2ev32VsiSTH30mFAjJ20bGtupIDh8ymyA/vgrj65rXZo9PkZy3LyhB0k80fdYDJmmw0tRQLF8Rkwt9ELwXXEsXlBShgGhpzphdp2h2L2HLO06PVODzNYkY0IoNpViyBErz7ndSV/IO/SZFt91uN9F9TrgWowb+3VqgFAh5NWwgLNOlXNLqFxnm1j/Ownuz+bnklZgvL0h3WxUXWj3BQoQbUpM/yJSbos9uGV3H/ITwUoHdUN6yKycmdsAxRW1Hv9RuwiMvBKjr75lVF+yM0ojH8F+VwXeSLdQTiywQG86aKk0uQDvQuJJ269z61UOuE/4NY0NJzoKPG7IhApH4A/hgdOGjAhVCix2DyWePp1mRnkrtPLsL1vbmtFj5cTTSLllUva46SQB2OLRWJRXkyCLjoKlnoWIzsn8vtr7jD/2N0Njsr35KPq9ILAKykXmss2tESuDUOTm2Ic5yBuw0AXQCdvkb/Zyb5MxdtQjOAZze9HzyJdPoX3mmFjJCZrXD9lnu3FgmxGarerBo8TDUBNIKpZ6qfMFw3MQtWBod+nZeYhl4yU0LA/b6v07ZPshIkI0ikVgJWVn3eAD3Y02hLIsACMm0G3qkHvdjoU5PfTynCO6zk1ajhiSdmHHYz7Nf/uy4dpMMvEQi06kyxV8q8='
 before_install:
   - gem install bundler
 script:
@@ -21,8 +18,3 @@ before_script:
   - RAILS_ENV=test bundle exec rails db:migrate
   - RAILS_ENV=test bundle exec rake sunspot:solr:start
   - sleep 30
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - "./cc-test-reporter before-build"
-after_script:
-  - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"

--- a/config/database_indexes.yml
+++ b/config/database_indexes.yml
@@ -3,12 +3,67 @@ default: &default
     - columns: siren
       options:
         unique: true
+    - columns: statut_diffusion
+    - columns: unite_purgee
+    - columns: date_creation
+    - columns: sigle
+    - columns: sexe
+    - columns: prenom_1
+    - columns: prenom_usuel
+    - columns: pseudonyme
+    - columns: identifiant_association
+    - columns: tranche_effectifs
+    - columns: annee_effectifs
+    - columns: date_dernier_traitement
+    - columns: nombre_periodes
+    - columns: categorie_entreprise
+    - columns: annee_categorie_entreprise
+    - columns: date_fin
+    - columns: date_debut
+    - columns: etat_administratif
+    - columns: nom
+    - columns: nom_usage
+    - columns: denomination
+    - columns: denomination_usuelle_1
+    - columns: categorie_juridique
+    - columns: activite_principale
+    - columns: economie_sociale_solidaire
+    - columns: caractere_employeur
   etablissements:
     - columns: siren
     - columns: unite_legale_id
     - columns: siret
       options:
         unique: true
+    - columns: statut_diffusion
+    - columns: date_creation
+    - columns: tranche_effectifs
+    - columns: annee_effectifs
+    - columns: activite_principale_registre_metiers
+    - columns: date_dernier_traitement
+    - columns: etablissement_siege
+    - columns: nombre_periodes
+    - columns: code_postal
+    - columns: code_commune
+    - columns: code_cedex
+    - columns: code_pays_etranger
+    - columns: code_postal_2
+    - columns: code_commune_2
+    - columns: code_cedex_2
+    - columns: code_pays_etranger_2
+    - columns: date_debut
+    - columns: etat_administratif
+    - columns: enseigne_1
+    - columns: denomination_usuelle
+    - columns: activite_principale
+    - columns: nomenclature_activite_principale
+    - columns: caractere_employeur
+    - columns: libelle_commune
+    - columns: libelle_commune_etranger
+    - columns: libelle_pays_etranger
+    - columns: libelle_commune_2
+    - columns: libelle_commune_etranger_2
+    - columns: libelle_pays_etranger_2
 
 development:
   <<: *default

--- a/spec/concepts/stock/helper/database_indexes_spec.rb
+++ b/spec/concepts/stock/helper/database_indexes_spec.rb
@@ -8,11 +8,6 @@ describe Stock::Helper::DatabaseIndexes do
   it 'yields table_names, indexes and options' do
     expect do |b|
       subject.each_index_configuration(&b)
-    end.to yield_successive_args(
-      [:unites_legales, 'siren', { unique: true }],
-      [:etablissements, 'siren', {}],
-      [:etablissements, 'unite_legale_id', {}],
-      [:etablissements, 'siret', { unique: true }]
-    )
+    end.to yield_control.exactly(59).times
   end
 end


### PR DESCRIPTION
Added about 75% of all fields as index, if they have
any interest being indexed.
As an example, `code_postal` is a very important field to index, since
a lot of searches might include it, whereas
`nic` have no interest being indexed.

This needs extensive testing in sandbox to be sure we don't increase import time too much.

This PR is part of #214 

(WIP until specs are done)