### PR TITLE
Daily updates INSEE token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-/config/secrets.yml
-
 # Ignore bundler config.
 /.bundle
 
@@ -45,3 +43,6 @@ sunspot-solr.pid
 
 # Ignore code coverage report
 coverage/*
+
+# Ignore INSEE secrets
+/config/insee_secrets.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,7 @@ AllCops:
     - 'app/controllers/api/v1/**/*'
 
 Metrics/LineLength:
-  Max: 120
-  IgnoredPatterns:
-    - 'logger'
+  Enabled: false
 
 Metrics/BlockLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
 script:
   - bundle exec rubocop
   - bundle exec rspec
-  - bundle exec rspec --tag real_tcp_requests
 before_script:
   - psql -U postgres -f postgresql_setup.txt
   - RAILS_ENV=test bundle exec rails db:migrate

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :test do
   gem 'simplecov'
   gem 'simplecov-console'
   gem 'timecop'
+  gem 'unindent'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,6 +374,7 @@ GEM
       thread_safe (~> 0.1)
     uber (0.1.0)
     unicode-display_width (1.3.2)
+    unindent (1.0)
     vcr (4.0.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -446,10 +447,11 @@ DEPENDENCIES
   sunspot_solr
   timecop
   trailblazer-rails
+  unindent
   vcr
   webmock
   whenever
   whirly
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -267,6 +267,14 @@ Pour installer rapidement & efficacement l'API en environnement de production,
 vous pouvez vous referer a la documentation sur [sirene_as_api_ansible](https://github.com/etalab/sirene_as_api_ansible)
 et utiliser les scripts de déploiement automatiques.
 
+## Token de l'API INSEE
+
+Afin de récupérer automatiquement les mises à jours quotidiennes de l'API SIRENE de l'INSEE il est nécessaire de renseigner `insee_credentials` dans `config/secrets.yml`.
+
+Pour obtenir un token rendez-vous sur https://api.insee.fr/ dans : "Mes Applications"->sélectionnez ou créer une application->"Clefs et Jetons d'accès"->copiez la chaine de charactère sous "Génération des jetons d'accès" (dans l'exemple de code)
+
+_Attention_, il ne s'agit ni de la _Clef du consommateur_, ni du _Secret du consommateur_, ni du _Jeton d'accès_.
+
 ## Nouveau : Installation avec Docker
 
 Si vous disposez de docker et de docker-compose, vous pouvez lancer le serveur en local avec les commandes suivantes :

--- a/app/concepts/insee/operation/renew_token.rb
+++ b/app/concepts/insee/operation/renew_token.rb
@@ -1,0 +1,51 @@
+module INSEE
+  module Operation
+    class RenewToken < Trailblazer::Operation
+      step :file_exist?
+      step :load_file
+      step :verify_expiration
+      failure :renew_token, Output(:success) => Track(:success)
+      step :secrets!
+
+      def file_exist?(_, **)
+        File.exist?(filename)
+      end
+
+      def load_file(ctx, **)
+        ctx[:insee_secrets] = YAML.load_file(filename)
+      end
+
+      def verify_expiration(_, insee_secrets:, **)
+        expiration_date = Time.zone.at(insee_secrets['expiration_date'])
+        expiration_date > Time.zone.now
+      end
+
+      def renew_token(ctx, **)
+        ctx[:insee_secrets] = insee_secrets.as_json
+        File.write(filename, ctx[:insee_secrets].to_yaml)
+      end
+
+      def secrets!(ctx, insee_secrets:, **)
+        ctx[:insee_token] = insee_secrets['token']
+        ctx[:insee_expiration_date] = insee_secrets['expiration_date']
+      end
+
+      private
+
+      def insee_secrets
+        {
+          token: request[:token],
+          expiration_date: request[:expiration_date]
+        }
+      end
+
+      def request
+        @request ||= INSEE::Request::RenewToken.call
+      end
+
+      def filename
+        Rails.root.join('config', 'insee_secrets.yml')
+      end
+    end
+  end
+end

--- a/app/concepts/insee/operation/renew_token.rb
+++ b/app/concepts/insee/operation/renew_token.rb
@@ -3,9 +3,9 @@ module INSEE
     class RenewToken < Trailblazer::Operation
       step :file_exist?
       step :load_file
-      step :verify_expiration
-      failure Nested(INSEE::Request::RenewToken), Output(:success) => Track(:token_renewed)
-      step :persist_secrets, magnetic_to: [:token_renewed]
+      step :verify_expiration, Output(:success) => 'End.success'
+      failure Nested(INSEE::Request::RenewToken), Output(:success) => Track(:success)
+      step :persist_secrets
 
       def file_exist?(_, **)
         File.exist?(filename)

--- a/app/concepts/insee/request/renew_token.rb
+++ b/app/concepts/insee/request/renew_token.rb
@@ -22,7 +22,7 @@ module INSEE
         ctx[:expiration_date] = Time.zone.now.to_i + response_json[:expires_in]
       end
 
-      def log_renew_failed(ctx, response:, logger:, **)
+      def log_renew_failed(_, response:, logger:, **)
         logger.error "Failed to renew INSEE token code: #{response.code}, body: #{response.body}"
       end
 

--- a/app/concepts/insee/request/renew_token.rb
+++ b/app/concepts/insee/request/renew_token.rb
@@ -1,0 +1,44 @@
+module INSEE
+  module Request
+    class RenewToken < Trailblazer::Operation
+      step :get
+      step :parse_response
+
+      def get(ctx, **)
+        ctx[:response] = http.request(request)
+      end
+
+      def parse_response(ctx, response:, **)
+        response_json = JSON.parse(response.body, symbolize_names: true)
+
+        ctx[:token] = response_json[:access_token]
+        ctx[:expires_in] = response_json[:expires_in]
+        ctx[:expiration_date] = Time.zone.now.to_i + response_json[:expires_in]
+      end
+
+      private
+
+      def http
+        http = Net::HTTP.new(url.host, url.port)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http
+      end
+
+      def request
+        request = Net::HTTP::Post.new(url)
+        request['authorization'] = "Basic #{token}"
+        request.body = 'grant_type=client_credentials'
+        request
+      end
+
+      def url
+        URI('https://api.insee.fr/token')
+      end
+
+      def token
+        Rails.application.config_for(:secrets)['insee_credentials']
+      end
+    end
+  end
+end

--- a/app/serializers/payload_serializer.rb
+++ b/app/serializers/payload_serializer.rb
@@ -13,7 +13,6 @@ module PayloadSerializer
     end
 
     # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/LineLength
     def body
       {
         sirene: {
@@ -54,7 +53,6 @@ module PayloadSerializer
       }
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/LineLength
 
     def data_from_sirene
       if !@result_siege.nil?

--- a/config/initializers/insee_renew_token.rb
+++ b/config/initializers/insee_renew_token.rb
@@ -1,0 +1,4 @@
+unless %w[development test].include?(Rails.env)
+  puts 'Renewing INSEE token'
+  INSEE::Operation::RenewToken.call
+end

--- a/config/initializers/insee_renew_token.rb
+++ b/config/initializers/insee_renew_token.rb
@@ -1,4 +1,0 @@
-unless %w[development test].include?(Rails.env)
-  puts 'Renewing INSEE token'
-  INSEE::Operation::RenewToken.call
-end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -9,16 +9,22 @@
 
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
+---
+defaults: &DEFAULTS
+  insee_credentials: dummy_credentials
 
 development:
+  <<: *DEFAULTS
   secret_key_base: 4ed24e29466c7e2054a0b3439fe20b70237d1d23dcdf1cd732fd789500bf8ec17c96152705232712efa57ab31a4646992723998ac15908937a513fe0a576abbb
 
 test:
+  <<: *DEFAULTS
   secret_key_base: 669649216b1bd51508a27ace8c08b87dd7e7ce811d5f5af2deae385d7c3f0ed637de3eed1c610678d703bfb04849fac839740466a99ba0419128d4c275b0b5f3
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
+  <<: *DEFAULTS
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   OVH_APPLICATION_KEY: dummy_value1
   OVH_APPLICATION_SECRET: dummy_value2

--- a/spec/concepts/insee/operation/renew_token_spec.rb
+++ b/spec/concepts/insee/operation/renew_token_spec.rb
@@ -1,39 +1,54 @@
 require 'rails_helper'
 
 describe INSEE::Operation::RenewToken do
-  subject { described_class.call }
+  subject { described_class.call(logger: logger) }
 
+  let(:logger) { instance_spy Logger }
   let(:mocked_token) { 'this a token' }
   let(:expected_token) { 'ab380ad7-5725-33d6-9d57-18a40e209021' }
   let(:expected_timestamp) { Time.zone.now.to_i + 603_438 }
+  let(:file_path) { Rails.root.join('config', 'insee_secrets.yml') }
 
   before { Timecop.freeze }
-  after { File.delete(described_class.new.send(:filename)) }
 
   context 'when token file is found' do
     before { create_token(expiration_timestamp) }
+    after { File.delete(file_path) }
 
     context 'when token is not expired' do
       let(:expiration_timestamp) { 1.day.since.to_i }
 
       its(:success?) { is_expected.to be_truthy }
-      its([:insee_token]) { is_expected.to eq mocked_token }
-      its([:insee_expiration_date]) { is_expected.to eq expiration_timestamp }
+      its([:token]) { is_expected.to eq mocked_token }
+      its([:expiration_date]) { is_expected.to eq expiration_timestamp }
     end
 
     context 'when token is expired', vcr: { cassette_name: 'insee/renew_token' } do
       let(:expiration_timestamp) { 1.day.ago.to_i }
 
       its(:success?) { is_expected.to be_truthy }
-      its([:insee_token]) { is_expected.to eq expected_token }
-      its([:insee_expiration_date]) { is_expected.to eq expected_timestamp }
+      its([:token]) { is_expected.to eq expected_token }
+      its([:expiration_date]) { is_expected.to eq expected_timestamp }
     end
   end
 
   context 'when token file is not found', vcr: { cassette_name: 'insee/renew_token' } do
+    after { File.delete(file_path) }
+
     its(:success?) { is_expected.to be_truthy }
-    its([:insee_token]) { is_expected.to eq expected_token }
-    its([:insee_expiration_date]) { is_expected.to eq expected_timestamp }
+    its([:token]) { is_expected.to eq expected_token }
+    its([:expiration_date]) { is_expected.to eq expected_timestamp }
+  end
+
+  context 'when renewing token failed', vcr: { cassette_name: 'insee/renew_token' } do
+    before { allow_any_instance_of(Net::HTTPOK).to receive(:code).and_return('500') }
+
+    its(:success?) { is_expected.to be_falsey }
+
+    it 'logs an error' do
+      subject
+      expect(logger).to have_received(:error)
+    end
   end
 
   def create_token(expiration_timestamp)

--- a/spec/concepts/insee/operation/renew_token_spec.rb
+++ b/spec/concepts/insee/operation/renew_token_spec.rb
@@ -12,21 +12,21 @@ describe INSEE::Operation::RenewToken do
   before { Timecop.freeze }
 
   context 'when token file is found' do
-    before { create_token(expiration_timestamp) }
+    before { create_token(mocked_expiration_timestamp) }
     after { File.delete(file_path) }
 
     context 'when token is not expired' do
-      let(:expiration_timestamp) { 1.day.since.to_i }
+      let(:mocked_expiration_timestamp) { 1.day.since.to_i }
 
-      its(:success?) { is_expected.to be_truthy }
+      its(:success?) { is_expected.to eq(true) }
       its([:token]) { is_expected.to eq mocked_token }
-      its([:expiration_date]) { is_expected.to eq expiration_timestamp }
+      its([:expiration_date]) { is_expected.to eq mocked_expiration_timestamp }
     end
 
     context 'when token is expired', vcr: { cassette_name: 'insee/renew_token' } do
-      let(:expiration_timestamp) { 1.day.ago.to_i }
+      let(:mocked_expiration_timestamp) { 1.day.ago.to_i }
 
-      its(:success?) { is_expected.to be_truthy }
+      its(:success?) { is_expected.to eq(true) }
       its([:token]) { is_expected.to eq expected_token }
       its([:expiration_date]) { is_expected.to eq expected_timestamp }
     end
@@ -35,7 +35,7 @@ describe INSEE::Operation::RenewToken do
   context 'when token file is not found', vcr: { cassette_name: 'insee/renew_token' } do
     after { File.delete(file_path) }
 
-    its(:success?) { is_expected.to be_truthy }
+    its(:success?) { is_expected.to eq(true) }
     its([:token]) { is_expected.to eq expected_token }
     its([:expiration_date]) { is_expected.to eq expected_timestamp }
   end
@@ -43,7 +43,7 @@ describe INSEE::Operation::RenewToken do
   context 'when renewing token failed', vcr: { cassette_name: 'insee/renew_token' } do
     before { allow_any_instance_of(Net::HTTPOK).to receive(:code).and_return('500') }
 
-    its(:success?) { is_expected.to be_falsey }
+    its(:success?) { is_expected.to eq(false) }
 
     it 'logs an error' do
       subject
@@ -51,12 +51,12 @@ describe INSEE::Operation::RenewToken do
     end
   end
 
-  def create_token(expiration_timestamp)
+  def create_token(mocked_expiration_timestamp)
     File.open(described_class.new.send(:filename), 'w+') do |file|
       content = <<-YML
         ---
         token: #{mocked_token}
-        expiration_date: #{expiration_timestamp}
+        expiration_date: #{mocked_expiration_timestamp}
       YML
 
       file.write(content.unindent)

--- a/spec/concepts/insee/request/renew_token_spec.rb
+++ b/spec/concepts/insee/request/renew_token_spec.rb
@@ -1,12 +1,27 @@
 require 'rails_helper'
 
 describe INSEE::Request::RenewToken, vcr: { cassette_name: 'insee/renew_token' } do
-  subject { described_class.call }
+  subject { described_class.call(logger: logger) }
+
+  let(:logger) { instance_spy Logger }
 
   before { Timecop.freeze }
 
-  its(:success?) { is_expected.to be_truthy }
-  its([:token]) { is_expected.to eq 'ab380ad7-5725-33d6-9d57-18a40e209021' }
-  its([:expires_in]) { is_expected.to eq 603_438 }
-  its([:expiration_date]) { is_expected.to eq(Time.zone.now.to_i + 603_438) }
+  context 'when INSEE is UP' do
+    its(:success?) { is_expected.to be_truthy }
+    its([:token]) { is_expected.to eq 'ab380ad7-5725-33d6-9d57-18a40e209021' }
+    its([:expires_in]) { is_expected.to eq 603_438 }
+    its([:expiration_date]) { is_expected.to eq(Time.zone.now.to_i + 603_438) }
+  end
+
+  context 'when INSEE is DOWN' do
+    before { allow_any_instance_of(Net::HTTPOK).to receive(:code).and_return('500') }
+
+    its(:success?) { is_expected.to be_falsey }
+
+    it 'logs an error' do
+      subject
+      expect(logger).to have_received(:error).with(/Failed to renew INSEE token/)
+    end
+  end
 end

--- a/spec/concepts/insee/request/renew_token_spec.rb
+++ b/spec/concepts/insee/request/renew_token_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe INSEE::Request::RenewToken, vcr: { cassette_name: 'insee/renew_token' } do
+  subject { described_class.call }
+
+  before { Timecop.freeze }
+
+  its(:success?) { is_expected.to be_truthy }
+  its([:token]) { is_expected.to eq 'ab380ad7-5725-33d6-9d57-18a40e209021' }
+  its([:expires_in]) { is_expected.to eq 603_438 }
+  its([:expiration_date]) { is_expected.to eq(Time.zone.now.to_i + 603_438) }
+end

--- a/spec/fixtures/vcr_cassettes/insee/renew_token.yml
+++ b/spec/fixtures/vcr_cassettes/insee/renew_token.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.insee.fr/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.insee.fr
+      Authorization:
+      - Basic <INSEE_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-store
+      X-Content-Type-Options:
+      - nosniff
+      Set-Cookie:
+      - INSEE=1863723786.58148.0000;secure; expires=Wed, 23-Oct-2019 13:13:48 GMT;
+        path=/
+      - pdapimgateway=1846946570.22560.0000;secure; expires=Wed, 23-Oct-2019 13:13:48
+        GMT; path=/
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Oct 2019 12:53:47 GMT
+      Transfer-Encoding:
+      - chunked
+      Strict-Transport-Security:
+      - max-age=100000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"ab380ad7-5725-33d6-9d57-18a40e209021","scope":"am_application_scope
+        default","token_type":"Bearer","expires_in":603438}'
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 12:53:48 GMT
+recorded_with: VCR 4.0.0

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 
 require 'spec_helper'
+require 'vcr_helper'
 require 'active_jobs_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,18 +38,6 @@ if ARGV.grep(/spec\.rb/).empty?
   end
 end
 
-VCR.configure do |config|
-  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
-  config.hook_into :webmock
-  config.configure_rspec_metadata!
-  config.default_cassette_options[:allow_playback_repeats] = true
-  config.allow_http_connections_when_no_cassette = false
-  # Config ignore_request to stop VCR from managing Solr server requests
-  config.ignore_request do |request|
-    URI(request.uri).port == 8981
-  end
-end
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -1,0 +1,16 @@
+VCR.configure do |c|
+  c.allow_http_connections_when_no_cassette = false
+  c.ignore_localhost = true
+  c.hook_into :webmock
+  c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  c.configure_rspec_metadata!
+  c.default_cassette_options = { record: :new_episodes, allow_playback_repeats: true, match_requests_on: %i[method uri body] }
+
+  # Config ignore_request to stop VCR from managing Solr server requests
+  c.ignore_request do |request|
+    URI(request.uri).port == 8981
+  end
+
+  # VCR client's filters
+  c.filter_sensitive_data('<INSEE_CREDENTIALS>') { Rails.application.config_for(:secrets)['insee_credentials'] }
+end


### PR DESCRIPTION
Première PR d'une longue séries pour l'ajout des mises à jours quotidiennes de l'INSEE.

Ici il s'agit d'avoir une opération Trailblazer pour récupérer un token lorsqu'il est expiré/inexistant.

Il y a deux opérations :
- l'une _request_ pour faire la requête HTTP (1)
- l'autre pour gérer le load / save / check-expiration

1. Cette PR c'est un peu un test de comment je vois les appels à des APIs avec Trailblazer ; il y aura probablement de l'héritage/opération-nesté qui arrivera pour éviter la duplication mais pas pour le moment.

J'ai revu légèrement la conf VCR

J'ai indiqué dans le README comment récupérer un token, c'est indispensable car c'est pas clair dans l'interface INSEE lequel il faut prendre (il y en a 4...)