### PR TITLE
Smooth stock import

### DIFF
--- a/app/concepts/files/helper/csv_reader.rb
+++ b/app/concepts/files/helper/csv_reader.rb
@@ -17,7 +17,7 @@ module Files
       private
 
       def chunk_size
-        2_000
+        Stock::Task::ImportCSV::CHUNK_SIZE
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/app/concepts/stock/operation/import.rb
+++ b/app/concepts/stock/operation/import.rb
@@ -3,12 +3,12 @@ class Stock
     class Import < Trailblazer::Operation
       step :uri
       step :model
-      step :table_name
       step Nested Files::Operation::Download
       step Nested Files::Operation::Extract
       step :csv
+      step :swap_with_temp_model
+      step :table_name
       step Nested Task::TruncateTable
-      step Nested Task::DropIndexes
       step Nested Task::ImportCSV
 
       step :delete_tmp_files
@@ -22,12 +22,23 @@ class Stock
         ctx[:model] = stock.class::RELATED_MODEL
       end
 
-      def table_name(ctx, model:, **)
-        ctx[:table_name] = model.table_name
-      end
-
       def csv(ctx, extracted_file:, **)
         ctx[:csv] = extracted_file
+      end
+
+      def swap_with_temp_model(ctx, model:, **)
+        temp_model_name = "TmpModel#{model.name}"
+
+        Object.const_set(temp_model_name, Class.new(model)) unless Object.const_defined?(temp_model_name)
+
+        temp_model = temp_model_name.constantize
+        temp_model.table_name = model.table_name + '_tmp'
+
+        ctx[:model] = temp_model
+      end
+
+      def table_name(ctx, model:, **)
+        ctx[:table_name] = model.table_name
       end
 
       def delete_tmp_files(_, extracted_file:, **)

--- a/app/concepts/stock/operation/import.rb
+++ b/app/concepts/stock/operation/import.rb
@@ -41,7 +41,8 @@ class Stock
         ctx[:table_name] = model.table_name
       end
 
-      def delete_tmp_files(_, extracted_file:, **)
+      def delete_tmp_files(_, file_path:, extracted_file:, **)
+        FileUtils.rm_rf file_path
         FileUtils.rm_rf extracted_file
       end
     end

--- a/app/concepts/stock/operation/post_import.rb
+++ b/app/concepts/stock/operation/post_import.rb
@@ -4,10 +4,10 @@ class Stock
       step :stock_unite_legale_imported?
       step :stock_etablissement_imported?
       fail :log_stock_not_imported, Output(:success) => 'End.success'
+      step Nested Task::CreateAssociations
+      step Nested Task::DropIndexes
+      step Nested Task::SwapTableNames
       step Nested Task::CreateIndexes
-      pass :log_associations_starts
-      step :create_associations
-      pass :log_associations_completed
 
       def stock_unite_legale_imported?(_ctx, **)
         StockUniteLegale.current&.imported?
@@ -17,34 +17,8 @@ class Stock
         StockEtablissement.current&.imported?
       end
 
-      def create_associations(_ctx, logger:, **)
-        ActiveRecord::Base.connection.execute(sql)
-      rescue ActiveRecord::ActiveRecordError
-        logger.error "Association failed: #{$ERROR_INFO.message}"
-        false
-      end
-
-      def log_associations_starts(_, logger:, **)
-        logger.info 'Models associations starts'
-      end
-
-      def log_associations_completed(_, logger:, **)
-        logger.info 'Models associations completed'
-      end
-
       def log_stock_not_imported(_ctx, logger:, **)
         logger.info 'Other import not finished'
-      end
-
-      private
-
-      def sql
-        <<-END_SQL
-        UPDATE etablissements
-        SET unite_legale_id = unites_legales.id
-        FROM unites_legales
-        WHERE etablissements.siren = unites_legales.siren
-        END_SQL
       end
     end
   end

--- a/app/concepts/stock/task/create_associations.rb
+++ b/app/concepts/stock/task/create_associations.rb
@@ -1,0 +1,35 @@
+class Stock
+  module Task
+    class CreateAssociations < Trailblazer::Operation
+      pass :log_associations_starts
+      step :create_associations
+      pass :log_associations_completed
+
+      def create_associations(_ctx, logger:, **)
+        ActiveRecord::Base.connection.execute(sql)
+      rescue ActiveRecord::ActiveRecordError
+        logger.error "Association failed: #{$ERROR_INFO.message}"
+        false
+      end
+
+      def log_associations_starts(_, logger:, **)
+        logger.info 'Models associations starts'
+      end
+
+      def log_associations_completed(_, logger:, **)
+        logger.info 'Models associations completed'
+      end
+
+      private
+
+      def sql
+        <<-END_SQL
+        UPDATE etablissements_tmp
+        SET unite_legale_id = unites_legales_tmp.id
+        FROM unites_legales_tmp
+        WHERE etablissements_tmp.siren = unites_legales_tmp.siren
+        END_SQL
+      end
+    end
+  end
+end

--- a/app/concepts/stock/task/drop_indexes.rb
+++ b/app/concepts/stock/task/drop_indexes.rb
@@ -3,8 +3,21 @@ class Stock
     class DropIndexes < Trailblazer::Operation
       include Stock::Helper::DatabaseIndexes
 
+      step :table_name_unite_legale
       step :drop_indexes
       step :log_indexes_dropped
+
+      step :table_name_etablissement
+      step :drop_indexes
+      step :log_indexes_dropped
+
+      def table_name_unite_legale(ctx, **)
+        ctx[:table_name] = UniteLegale.table_name
+      end
+
+      def table_name_etablissement(ctx, **)
+        ctx[:table_name] = Etablissement.table_name
+      end
 
       def drop_indexes(_, table_name:, **)
         each_index_configuration do |index_table_name, columns, options|

--- a/app/concepts/stock/task/import_csv.rb
+++ b/app/concepts/stock/task/import_csv.rb
@@ -8,6 +8,8 @@ class Stock
       step :import_csv
       pass :log_import_completed
 
+      CHUNK_SIZE = 10_000
+
       def file_exists?(_, csv:, **)
         File.exist? csv
       end
@@ -42,7 +44,7 @@ class Stock
 
       def basic_options
         {
-          chunk_size: 2_000,
+          chunk_size: CHUNK_SIZE,
           col_sep: ',',
           row_sep: "\n",
           downcase_header: false,

--- a/app/concepts/stock/task/swap_table_names.rb
+++ b/app/concepts/stock/task/swap_table_names.rb
@@ -1,0 +1,40 @@
+class Stock
+  module Task
+    class SwapTableNames < Trailblazer::Operation
+      pass :log_renaming_starts
+      step :swap_unite_legale
+      step :swap_etablissement
+      pass :log_renaming_done
+
+      def swap_unite_legale(_, **)
+        swap_command(UniteLegale.table_name)
+      end
+
+      def swap_etablissement(_, **)
+        swap_command(Etablissement.table_name)
+      end
+
+      def log_renaming_starts(_, logger:, **)
+        logger.info 'Table renaming starts'
+      end
+
+      def log_renaming_done(_, logger:, **)
+        logger.info 'Table renaming done'
+      end
+
+      private
+
+      def swap_command(table_name)
+        ActiveRecord::Base.connection.execute swap_sql(table_name)
+      end
+
+      def swap_sql(table_name)
+        <<-END_SQL
+        ALTER TABLE "#{table_name}" RENAME TO "#{table_name + '_swap'}";
+        ALTER TABLE "#{table_name + '_tmp'}" RENAME TO "#{table_name}";
+        ALTER TABLE "#{table_name + '_swap'}" RENAME TO "#{table_name + '_tmp'}";
+        END_SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20191126124448_create_unites_legales_tmp.rb
+++ b/db/migrate/20191126124448_create_unites_legales_tmp.rb
@@ -1,0 +1,42 @@
+class CreateUnitesLegalesTmp < ActiveRecord::Migration[5.0]
+  def change
+    create_table :unites_legales_tmp do |t|
+      t.string :siren
+      t.string :statut_diffusion
+      t.string :unite_purgee
+      t.string :date_creation
+      t.string :sigle
+      t.string :sexe
+      t.string :prenom_1
+      t.string :prenom_2
+      t.string :prenom_3
+      t.string :prenom_4
+      t.string :prenom_usuel
+      t.string :pseudonyme
+      t.string :identifiant_association
+      t.string :tranche_effectifs
+      t.string :annee_effectifs
+      t.string :date_dernier_traitement
+      t.string :nombre_periodes
+      t.string :categorie_entreprise
+      t.string :annee_categorie_entreprise
+      t.string :date_fin
+      t.string :date_debut
+      t.string :etat_administratif
+      t.string :nom
+      t.string :nom_usage
+      t.string :denomination
+      t.string :denomination_usuelle_1
+      t.string :denomination_usuelle_2
+      t.string :denomination_usuelle_3
+      t.string :categorie_juridique
+      t.string :activite_principale
+      t.string :nomenclature_activite_principale
+      t.string :nic_siege
+      t.string :economie_sociale_solidaire
+      t.string :caractere_employeur
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191126124456_create_etablissements_tmp.rb
+++ b/db/migrate/20191126124456_create_etablissements_tmp.rb
@@ -1,0 +1,65 @@
+class CreateEtablissementsTmp < ActiveRecord::Migration[5.0]
+  def change
+    create_table :etablissements_tmp do |t|
+      t.string :siren
+      t.string :nic
+      t.string :siret
+      t.string :statut_diffusion
+      t.string :date_creation
+      t.string :tranche_effectifs
+      t.string :annee_effectifs
+      t.string :activite_principale_registre_metiers
+      t.string :date_dernier_traitement
+      t.string :etablissement_siege
+      t.string :nombre_periodes
+      t.string :complement_adresse
+      t.string :numero_voie
+      t.string :indice_repetition
+      t.string :type_voie
+      t.string :libelle_voie
+      t.string :code_postal
+      t.string :libelle_commune
+      t.string :libelle_commune_etranger
+      t.string :distribution_speciale
+      t.string :code_commune
+      t.string :code_cedex
+      t.string :libelle_cedex
+      t.string :code_pays_etranger
+      t.string :libelle_pays_etranger
+      t.string :complement_adresse_2
+      t.string :numero_voie_2
+      t.string :indice_repetition_2
+      t.string :type_voie_2
+      t.string :libelle_voie_2
+      t.string :code_postal_2
+      t.string :libelle_commune_2
+      t.string :libelle_commune_etranger_2
+      t.string :distribution_speciale_2
+      t.string :code_commune_2
+      t.string :code_cedex_2
+      t.string :libelle_cedex_2
+      t.string :code_pays_etranger_2
+      t.string :libelle_pays_etranger_2
+      t.string :date_debut
+      t.string :etat_administratif
+      t.string :enseigne_1
+      t.string :enseigne_2
+      t.string :enseigne_3
+      t.string :denomination_usuelle
+      t.string :activite_principale
+      t.string :nomenclature_activite_principale
+      t.string :caractere_employeur
+      t.string :longitude
+      t.string :latitude
+      t.string :geo_score
+      t.string :geo_type
+      t.string :geo_adresse
+      t.string :geo_id
+      t.string :geo_ligne
+      t.string :geo_l4
+      t.string :geo_l5
+      t.integer :unite_legale_id
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.4
--- Dumped by pg_dump version 11.4
+-- Dumped from database version 10.10 (Ubuntu 10.10-0ubuntu0.18.04.1)
+-- Dumped by pg_dump version 10.10 (Ubuntu 10.10-0ubuntu0.18.04.1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -15,6 +15,20 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
 
 --
 -- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
@@ -133,6 +147,95 @@ CREATE SEQUENCE public.etablissements_id_seq
 --
 
 ALTER SEQUENCE public.etablissements_id_seq OWNED BY public.etablissements.id;
+
+
+--
+-- Name: etablissements_tmp; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etablissements_tmp (
+    id integer NOT NULL,
+    siren character varying,
+    nic character varying,
+    siret character varying,
+    statut_diffusion character varying,
+    date_creation character varying,
+    tranche_effectifs character varying,
+    annee_effectifs character varying,
+    activite_principale_registre_metiers character varying,
+    date_dernier_traitement character varying,
+    etablissement_siege character varying,
+    nombre_periodes character varying,
+    complement_adresse character varying,
+    numero_voie character varying,
+    indice_repetition character varying,
+    type_voie character varying,
+    libelle_voie character varying,
+    code_postal character varying,
+    libelle_commune character varying,
+    libelle_commune_etranger character varying,
+    distribution_speciale character varying,
+    code_commune character varying,
+    code_cedex character varying,
+    libelle_cedex character varying,
+    code_pays_etranger character varying,
+    libelle_pays_etranger character varying,
+    complement_adresse_2 character varying,
+    numero_voie_2 character varying,
+    indice_repetition_2 character varying,
+    type_voie_2 character varying,
+    libelle_voie_2 character varying,
+    code_postal_2 character varying,
+    libelle_commune_2 character varying,
+    libelle_commune_etranger_2 character varying,
+    distribution_speciale_2 character varying,
+    code_commune_2 character varying,
+    code_cedex_2 character varying,
+    libelle_cedex_2 character varying,
+    code_pays_etranger_2 character varying,
+    libelle_pays_etranger_2 character varying,
+    date_debut character varying,
+    etat_administratif character varying,
+    enseigne_1 character varying,
+    enseigne_2 character varying,
+    enseigne_3 character varying,
+    denomination_usuelle character varying,
+    activite_principale character varying,
+    nomenclature_activite_principale character varying,
+    caractere_employeur character varying,
+    longitude character varying,
+    latitude character varying,
+    geo_score character varying,
+    geo_type character varying,
+    geo_adresse character varying,
+    geo_id character varying,
+    geo_ligne character varying,
+    geo_l4 character varying,
+    geo_l5 character varying,
+    unite_legale_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etablissements_tmp_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etablissements_tmp_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etablissements_tmp_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etablissements_tmp_id_seq OWNED BY public.etablissements_tmp.id;
 
 
 --
@@ -387,10 +490,82 @@ ALTER SEQUENCE public.unites_legales_id_seq OWNED BY public.unites_legales.id;
 
 
 --
+-- Name: unites_legales_tmp; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.unites_legales_tmp (
+    id integer NOT NULL,
+    siren character varying,
+    statut_diffusion character varying,
+    unite_purgee character varying,
+    date_creation character varying,
+    sigle character varying,
+    sexe character varying,
+    prenom_1 character varying,
+    prenom_2 character varying,
+    prenom_3 character varying,
+    prenom_4 character varying,
+    prenom_usuel character varying,
+    pseudonyme character varying,
+    identifiant_association character varying,
+    tranche_effectifs character varying,
+    annee_effectifs character varying,
+    date_dernier_traitement character varying,
+    nombre_periodes character varying,
+    categorie_entreprise character varying,
+    annee_categorie_entreprise character varying,
+    date_fin character varying,
+    date_debut character varying,
+    etat_administratif character varying,
+    nom character varying,
+    nom_usage character varying,
+    denomination character varying,
+    denomination_usuelle_1 character varying,
+    denomination_usuelle_2 character varying,
+    denomination_usuelle_3 character varying,
+    categorie_juridique character varying,
+    activite_principale character varying,
+    nomenclature_activite_principale character varying,
+    nic_siege character varying,
+    economie_sociale_solidaire character varying,
+    caractere_employeur character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: unites_legales_tmp_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.unites_legales_tmp_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: unites_legales_tmp_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.unites_legales_tmp_id_seq OWNED BY public.unites_legales_tmp.id;
+
+
+--
 -- Name: etablissements id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.etablissements ALTER COLUMN id SET DEFAULT nextval('public.etablissements_id_seq'::regclass);
+
+
+--
+-- Name: etablissements_tmp id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etablissements_tmp ALTER COLUMN id SET DEFAULT nextval('public.etablissements_tmp_id_seq'::regclass);
 
 
 --
@@ -415,6 +590,13 @@ ALTER TABLE ONLY public.unites_legales ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
+-- Name: unites_legales_tmp id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.unites_legales_tmp ALTER COLUMN id SET DEFAULT nextval('public.unites_legales_tmp_id_seq'::regclass);
+
+
+--
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -428,6 +610,14 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 ALTER TABLE ONLY public.etablissements
     ADD CONSTRAINT etablissements_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etablissements_tmp etablissements_tmp_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etablissements_tmp
+    ADD CONSTRAINT etablissements_tmp_pkey PRIMARY KEY (id);
 
 
 --
@@ -460,6 +650,14 @@ ALTER TABLE ONLY public.stocks
 
 ALTER TABLE ONLY public.unites_legales
     ADD CONSTRAINT unites_legales_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: unites_legales_tmp unites_legales_tmp_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.unites_legales_tmp
+    ADD CONSTRAINT unites_legales_tmp_pkey PRIMARY KEY (id);
 
 
 --
@@ -579,6 +777,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190603115019'),
 ('20190606142656'),
 ('20190619121622'),
-('20190703100825');
+('20190703100825'),
+('20191126124448'),
+('20191126124456');
 
 

--- a/spec/concepts/stock/operation/import_spec.rb
+++ b/spec/concepts/stock/operation/import_spec.rb
@@ -17,12 +17,45 @@ describe Stock::Operation::Import, :trb do
     subject
   end
 
-  it 'drops the indexes' do
-    expect_to_call_nested_operation(Stock::Task::DropIndexes)
-    subject
+  it 'imports within a temporary model' do
+    model = subject[:model]
+    expect(model.table_name).to end_with('_tmp')
+    expect(model.name).to eq('TmpModelEtablissement')
   end
 
-  it 'imports data successfully' do
-    expect { subject }.to change(Etablissement, :count).by(3 - 1)
+  it 'imports data in the temporary table' do
+    tmp_model = subject[:model]
+    expect(tmp_model.count).to eq(3)
+  end
+
+  it 'truncates the temporary table before inserting' do
+    # create an entry in the temp table
+    model = stock.class::RELATED_MODEL
+    model.table_name = model.table_name + '_tmp'
+    etab = model.create
+    expect(model.first).to eq etab
+
+    # set back the real table name
+    model.table_name.slice!('_tmp')
+
+    tmp_model = subject[:model]
+    expect(tmp_model.count).to eq(3)
+  end
+
+  it 'does not imports data in the regular table' do
+    expect { subject }.not_to change(Etablissement, :count)
+    existing_etab.reload
+    expect(existing_etab).to be_persisted
+  end
+
+  it 'deletes extracted files when success' do
+    file = Pathname.new subject[:extracted_file]
+    expect(file).not_to exist
+  end
+
+  it 'deletes extracted files when failure' do
+    allow_any_instance_of(described_class).to receive(:csv).and_return(false)
+    file = Pathname.new subject[:extracted_file]
+    expect(file).not_to exist
   end
 end

--- a/spec/concepts/stock/operation/import_spec.rb
+++ b/spec/concepts/stock/operation/import_spec.rb
@@ -29,14 +29,12 @@ describe Stock::Operation::Import, :trb do
   end
 
   it 'truncates the temporary table before inserting' do
-    # create an entry in the temp table
     model = stock.class::RELATED_MODEL
-    model.table_name = model.table_name + '_tmp'
-    etab = model.create
-    expect(model.first).to eq etab
 
-    # set back the real table name
-    model.table_name.slice!('_tmp')
+    wrap_with_table_renamed(model) do
+      etab = model.create
+      expect(model.first).to eq etab
+    end
 
     tmp_model = subject[:model]
     expect(tmp_model.count).to eq(3)

--- a/spec/concepts/stock/operation/import_spec.rb
+++ b/spec/concepts/stock/operation/import_spec.rb
@@ -8,7 +8,7 @@ describe Stock::Operation::Import, :trb do
   let(:stock) { create :stock_etablissement }
   let(:logger) { instance_spy Logger }
   let!(:existing_etab) { create :etablissement }
-  let(:mocked_downloaded_file) do
+  let(:downloaded_fixture_file) do
     Rails.root.join('spec', 'fixtures', 'sample_etablissements.csv.gz').to_s
   end
 
@@ -54,6 +54,17 @@ describe Stock::Operation::Import, :trb do
   it 'deletes extracted files when failure' do
     allow_any_instance_of(described_class).to receive(:csv).and_return(false)
     file = Pathname.new subject[:extracted_file]
+    expect(file).not_to exist
+  end
+
+  it 'deletes downloaded files when success' do
+    file = Pathname.new subject[:file_path]
+    expect(file).not_to exist
+  end
+
+  it 'deletes downloaded files when failure' do
+    allow_any_instance_of(described_class).to receive(:csv).and_return(false)
+    file = Pathname.new subject[:file_path]
     expect(file).not_to exist
   end
 end

--- a/spec/concepts/stock/operation/load_etablissement_spec.rb
+++ b/spec/concepts/stock/operation/load_etablissement_spec.rb
@@ -63,7 +63,7 @@ describe Stock::Operation::LoadEtablissement, vcr: { cassette_name: 'cquest_geo_
       Rails.root.join 'tmp', 'files', 'sample_etablissements.csv'
     end
 
-    let(:mocked_downloaded_file) do
+    let(:downloaded_fixture_file) do
       Rails.root.join('spec', 'fixtures', 'sample_etablissements.csv.gz').to_s
     end
 

--- a/spec/concepts/stock/operation/load_unite_legale_spec.rb
+++ b/spec/concepts/stock/operation/load_unite_legale_spec.rb
@@ -63,7 +63,7 @@ describe Stock::Operation::LoadUniteLegale, vcr: { cassette_name: 'data_gouv_sir
       Rails.root.join 'tmp', 'files', 'sample_unites_legales.csv'
     end
 
-    let(:mocked_downloaded_file) do
+    let(:downloaded_fixture_file) do
       Rails.root.join('spec', 'fixtures', 'sample_unites_legales.csv.zip').to_s
     end
 

--- a/spec/concepts/stock/operation/post_import_spec.rb
+++ b/spec/concepts/stock/operation/post_import_spec.rb
@@ -4,9 +4,6 @@ describe Stock::Operation::PostImport, :trb do
   subject { described_class.call logger: logger }
 
   let(:logger) { instance_spy Logger }
-  let(:siren) { '005880034' }
-  let!(:unite_legale) { create :unite_legale, siren: siren }
-  let!(:etablissement) { create :etablissement, siren: siren }
 
   shared_examples 'not doing anything' do
     it { is_expected.to be_success }
@@ -18,8 +15,7 @@ describe Stock::Operation::PostImport, :trb do
 
     it 'does not create relationship' do
       subject
-      expect(unite_legale.etablissements).to be_empty
-      expect(etablissement.unite_legale).to be_nil
+      expect_not_to_call_nested_operation(Stock::Task::CreateAssociations)
     end
 
     it 'does not create database indexes' do
@@ -64,63 +60,24 @@ describe Stock::Operation::PostImport, :trb do
 
     it { is_expected.to be_success }
 
-    it 'logs association starts' do
-      subject
-      expect(logger).to have_received(:info).with('Models associations starts')
-    end
-
-    it 'logs associations done' do
-      subject
-      expect(logger).to have_received(:info).with('Models associations completed')
-    end
-
     it 'created the association' do
+      expect_to_call_nested_operation(Stock::Task::CreateAssociations)
       subject
-      unite_legale.reload
-      etablissement.reload
-      expect(unite_legale.etablissements.count).to eq 1
-      expect(etablissement.unite_legale).to eq unite_legale
+    end
+
+    it 'swaps table names' do
+      expect_to_call_nested_operation(Stock::Task::SwapTableNames)
+      subject
+    end
+
+    it 'drops indexes' do
+      expect_to_call_nested_operation(Stock::Task::DropIndexes)
+      subject
     end
 
     it 'creates database indexes' do
       expect_to_call_nested_operation(Stock::Task::CreateIndexes)
       subject
-    end
-
-    context 'when association failed' do
-      before do
-        allow_any_instance_of(described_class)
-          .to receive(:sql)
-          .and_return 'an invalid SQL statement'
-      end
-
-      it { is_expected.to be_failure }
-
-      it 'logs import starts' do
-        subject
-        expect(logger).to have_received(:info).with('Models associations starts')
-      end
-
-      it 'logs an error' do
-        subject
-        expect(logger).to have_received(:error).with(/Association failed:/)
-      end
-    end
-
-    context 'when Index creation failed' do
-      before do
-        allow_any_instance_of(Stock::Task::CreateIndexes)
-          .to receive(:create_indexes)
-          .and_return false
-      end
-
-      it { is_expected.to be_failure }
-
-      it 'does not create associations' do
-        expect_any_instance_of(described_class)
-          .not_to receive(:sql)
-        subject
-      end
     end
   end
 end

--- a/spec/concepts/stock/task/create_associations_spec.rb
+++ b/spec/concepts/stock/task/create_associations_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Stock::Task::CreateAssociations do
+  subject { described_class.call logger: logger }
+
+  let(:logger) { instance_spy Logger }
+  let(:siren) { '005880034' }
+
+  let!(:unite_legale) do
+    wrap_with_table_renamed(UniteLegale) do
+      create :unite_legale, siren: siren
+    end
+  end
+
+  let!(:etablissement) do
+    wrap_with_table_renamed(Etablissement) do
+      create :etablissement, siren: siren
+    end
+  end
+
+  it { is_expected.to be_success }
+
+  it 'logs association starts' do
+    subject
+    expect(logger).to have_received(:info).with('Models associations starts')
+  end
+
+  it 'logs associations done' do
+    subject
+    expect(logger).to have_received(:info).with('Models associations completed')
+  end
+
+  it 'created the association for etablissement' do
+    subject
+    etab = Etablissement.new(
+      get_raw_data('etablissements_tmp').first
+    )
+    expect(etab.unite_legale_id).to eq unite_legale.id
+  end
+
+  context 'when association failed' do
+    before do
+      allow_any_instance_of(described_class)
+        .to receive(:sql)
+        .and_return 'an invalid SQL statement'
+    end
+
+    it { is_expected.to be_failure }
+
+    it 'logs import starts' do
+      subject
+      expect(logger).to have_received(:info).with('Models associations starts')
+    end
+
+    it 'logs an error' do
+      subject
+      expect(logger).to have_received(:error).with(/Association failed:/)
+    end
+  end
+end

--- a/spec/concepts/stock/task/drop_indexes_spec.rb
+++ b/spec/concepts/stock/task/drop_indexes_spec.rb
@@ -1,51 +1,31 @@
 require 'rails_helper'
 
 describe Stock::Task::DropIndexes do
-  subject { described_class.call table_name: table_name, logger: logger }
+  subject { described_class.call logger: logger }
 
   let(:logger) { instance_spy Logger }
 
   before do
     Stock::Task::CreateIndexes.call logger: logger
   end
+
   after do
-    Stock::Task::DropIndexes.call table_name: UniteLegale.table_name, logger: logger
-    Stock::Task::DropIndexes.call table_name: Etablissement.table_name, logger: logger
+    Stock::Task::DropIndexes.call logger: logger
   end
 
-  context 'unites_legales table' do
-    let(:table_name) { UniteLegale.table_name }
-
-    it 'drops database indexes on UniteLegale' do
-      expect(:unites_legales).to have_unique_index_on(:siren)
-      subject
-      expect(:unites_legales).not_to have_unique_index_on(:siren)
-    end
-
-    it 'does not drop indexes on etablissements' do
-      subject
-      expect(:etablissements).to have_unique_index_on(:siret)
-      expect(:etablissements).to have_index_on(:siren)
-      expect(:etablissements).to have_index_on(:unite_legale_id)
-    end
+  it 'drops database indexes on UniteLegale' do
+    expect(:unites_legales).to have_unique_index_on(:siren)
+    subject
+    expect(:unites_legales).not_to have_unique_index_on(:siren)
   end
 
-  context 'etablissements table' do
-    let(:table_name) { Etablissement.table_name }
-
-    it 'drop database indexes on Etablissement' do
-      expect(:etablissements).to have_index_on(:siren)
-      expect(:etablissements).to have_index_on(:unite_legale_id)
-      expect(:etablissements).to have_unique_index_on(:siret)
-      subject
-      expect(:etablissements).not_to have_index_on(:siren)
-      expect(:etablissements).not_to have_index_on(:unite_legale_id)
-      expect(:etablissements).not_to have_unique_index_on(:siret)
-    end
-
-    it 'does not drop indexes on unites_legales' do
-      subject
-      expect(:unites_legales).to have_unique_index_on(:siren)
-    end
+  it 'drop database indexes on Etablissement' do
+    expect(:etablissements).to have_index_on(:siren)
+    expect(:etablissements).to have_index_on(:unite_legale_id)
+    expect(:etablissements).to have_unique_index_on(:siret)
+    subject
+    expect(:etablissements).not_to have_index_on(:siren)
+    expect(:etablissements).not_to have_index_on(:unite_legale_id)
+    expect(:etablissements).not_to have_unique_index_on(:siret)
   end
 end

--- a/spec/concepts/stock/task/swap_table_names_spec.rb
+++ b/spec/concepts/stock/task/swap_table_names_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe Stock::Task::SwapTableNames do
+  subject { described_class.call logger: logger }
+
+  let(:logger) { instance_spy Logger }
+
+  let!(:unite_legale) { create :unite_legale, siren: 'normal' }
+  let!(:etablissement) { create :etablissement, siret: 'normal' }
+
+  let!(:unite_legale_tmp) do
+    wrap_with_table_renamed(UniteLegale) do
+      create :unite_legale, siren: 'temp'
+    end
+  end
+
+  let!(:etablissement_tmp) do
+    wrap_with_table_renamed(Etablissement) do
+      create :etablissement, siret: 'temp'
+    end
+  end
+
+  example 'temp UniteLegale is now live' do
+    subject
+    expect(UniteLegale.first).to eq unite_legale_tmp
+  end
+
+  example 'old UniteLegale is now in temp table' do
+    subject
+    raw_unite_legale = UniteLegale.new(
+      get_raw_data('unites_legales_tmp').first
+    )
+
+    expect(raw_unite_legale).to eq unite_legale
+  end
+
+  it { is_expected.to be_success }
+
+  example 'temp Etablissement is now live' do
+    subject
+    expect(Etablissement.first).to eq etablissement_tmp
+  end
+
+  example 'old Etablissement is now in temp table' do
+    subject
+    raw_etablissement = Etablissement.new(
+      get_raw_data('etablissements_tmp').first
+    )
+
+    expect(raw_etablissement).to eq etablissement
+  end
+
+  it 'logs renaming messages' do
+    subject
+    expect(logger)
+      .to have_received(:info)
+      .with('Table renaming starts')
+      .ordered
+
+    expect(logger)
+      .to have_received(:info)
+      .with('Table renaming done')
+      .ordered
+  end
+end

--- a/spec/support/shared_contexts/stubbed_download.rb
+++ b/spec/support/shared_contexts/stubbed_download.rb
@@ -1,11 +1,16 @@
 shared_context 'stubbed download' do
   before do
+    # copy fixture file into tmp dir
+    file = Pathname.new(downloaded_fixture_file)
+    dest = Rails.root.join('tmp', 'files', file.basename).to_s
+    FileUtils.copy(downloaded_fixture_file, dest)
+
     # mock nested operation to return
     # the fixture file as the downloaded file
     allow_any_instance_of(Files::Operation::Download)
       .to receive(:download_file)
       .and_wrap_original do |_method, ctx, **|
-      ctx[:file_path] = mocked_downloaded_file
+      ctx[:file_path] = dest
     end
   end
 end

--- a/spec/support/shared_examples/importing_csv.rb
+++ b/spec/support/shared_examples/importing_csv.rb
@@ -18,7 +18,11 @@ shared_examples 'importing csv' do
       )
     end
 
-    pending 'persists 3 UniteLegale in temp table'
+    it 'persists 3 UniteLegale in temp table' do
+      subject
+      data = get_raw_data(model.table_name + '_tmp')
+      expect(data.count).to eq 3
+    end
 
     it 'deletes tmp file' do
       subject

--- a/spec/support/shared_examples/importing_csv.rb
+++ b/spec/support/shared_examples/importing_csv.rb
@@ -18,9 +18,7 @@ shared_examples 'importing csv' do
       )
     end
 
-    it 'persists 3 UniteLegale' do
-      expect { subject }.to change(model, :count).by 3
-    end
+    pending 'persists 3 UniteLegale in temp table'
 
     it 'deletes tmp file' do
       subject

--- a/spec/support/shared_examples/importing_csv.rb
+++ b/spec/support/shared_examples/importing_csv.rb
@@ -32,7 +32,7 @@ shared_examples 'importing csv' do
     it 'read the file by chunk' do
       expect(SmarterCSV)
         .to receive(:process)
-        .with(expected_tmp_file.to_s, a_hash_including(chunk_size: 2_000))
+        .with(expected_tmp_file.to_s, a_hash_including(chunk_size: 10_000))
       subject
     end
 

--- a/spec/support/sql_helper.rb
+++ b/spec/support/sql_helper.rb
@@ -1,0 +1,11 @@
+def wrap_with_table_renamed(model)
+  model.table_name = model.table_name + '_tmp'
+  item = yield
+  model.table_name.slice!('_tmp')
+  item
+end
+
+def get_raw_data(table_name)
+  sql = "SELECT * from #{table_name}"
+  ActiveRecord::Base.connection.execute sql
+end


### PR DESCRIPTION
Import du stock sans coupure de service et sans switch de serveur.

La solution consiste à importer dans une table `bidule_tmp` et ensuite de faire la bascule.
Conséquence:
- il n'y a plus de transaction lors de l'import
- la transaction est lors du `PostImport` 