### PR TITLE
Daily updates import status

### DIFF
--- a/app/concepts/daily_update/operation/update.rb
+++ b/app/concepts/daily_update/operation/update.rb
@@ -1,17 +1,11 @@
 class DailyUpdate
   module Operation
     class Update < Trailblazer::Operation
-      step :set_period_to_update
       pass :log_update_period
       step Nested INSEE::Operation::FetchUpdates
       step Nested Task::AdaptApiResults
       pass :log_supersede_starts
       step :supersede
-
-      def set_period_to_update(ctx, **)
-        ctx[:from] = Time.now.beginning_of_month
-        ctx[:to]   = Time.zone.now
-      end
 
       def supersede(_, model:, results:, logger:, **)
         results.each do |item|

--- a/app/concepts/daily_update/operation/update.rb
+++ b/app/concepts/daily_update/operation/update.rb
@@ -1,4 +1,4 @@
-module DailyUpdate
+class DailyUpdate
   module Operation
     class Update < Trailblazer::Operation
       step :set_period_to_update

--- a/app/concepts/daily_update/operation/update_database.rb
+++ b/app/concepts/daily_update/operation/update_database.rb
@@ -1,4 +1,4 @@
-module DailyUpdate
+class DailyUpdate
   module Operation
     class UpdateDatabase < Trailblazer::Operation
       step Nested Task::CurrentStockCompleted

--- a/app/concepts/daily_update/operation/update_database.rb
+++ b/app/concepts/daily_update/operation/update_database.rb
@@ -2,15 +2,41 @@ class DailyUpdate
   module Operation
     class UpdateDatabase < Trailblazer::Operation
       step Nested Task::CurrentStockCompleted
+      step :set_period_to_update
+      step :daily_updates_unite_legale
+      step :daily_updates_etablissement
       step :update_unite_legale
       step :update_etablissement
 
-      def update_unite_legale(_, **)
-        DailyUpdateModelJob.perform_later 'unite_legale'
+      def set_period_to_update(ctx, **)
+        ctx[:from] = Time.now.beginning_of_month
+        ctx[:to]   = Time.zone.now
       end
 
-      def update_etablissement(_, **)
-        DailyUpdateModelJob.perform_later 'etablissement'
+      def daily_updates_unite_legale(ctx, from:, to:, **)
+        ctx[:du_unite_legale] = DailyUpdate.create(
+          model_name_to_update: 'unite_legale',
+          status: 'PENDING',
+          from: from,
+          to: to
+        )
+      end
+
+      def daily_updates_etablissement(ctx, from:, to:, **)
+        ctx[:du_etablissement] = DailyUpdate.create(
+          model_name_to_update: 'etablissement',
+          status: 'PENDING',
+          from: from,
+          to: to
+        )
+      end
+
+      def update_unite_legale(_, du_unite_legale:, **)
+        DailyUpdateModelJob.perform_later du_unite_legale.id
+      end
+
+      def update_etablissement(_, du_etablissement:, **)
+        DailyUpdateModelJob.perform_later du_etablissement.id
       end
     end
   end

--- a/app/concepts/daily_update/task/adapt_api_results.rb
+++ b/app/concepts/daily_update/task/adapt_api_results.rb
@@ -1,4 +1,4 @@
-module DailyUpdate
+class DailyUpdate
   module Task
     class AdaptApiResults < Trailblazer::Operation
       pass :log_adapt_starts

--- a/app/concepts/daily_update/task/adapt_etablissement.rb
+++ b/app/concepts/daily_update/task/adapt_etablissement.rb
@@ -1,4 +1,4 @@
-module DailyUpdate
+class DailyUpdate
   module Task
     class AdaptEtablissement < Trailblazer::Operation
       step :get_latest_informations

--- a/app/concepts/daily_update/task/adapt_unite_legale.rb
+++ b/app/concepts/daily_update/task/adapt_unite_legale.rb
@@ -1,4 +1,4 @@
-module DailyUpdate
+class DailyUpdate
   module Task
     class AdaptUniteLegale < Trailblazer::Operation
       step :get_latest_informations

--- a/app/concepts/daily_update/task/current_stock_completed.rb
+++ b/app/concepts/daily_update/task/current_stock_completed.rb
@@ -1,4 +1,4 @@
-module DailyUpdate
+class DailyUpdate
   module Task
     class CurrentStockCompleted < Trailblazer::Operation
       step :stock_unite_legale_completed?

--- a/app/concepts/daily_update/task/supersede.rb
+++ b/app/concepts/daily_update/task/supersede.rb
@@ -1,4 +1,4 @@
-module DailyUpdate
+class DailyUpdate
   module Task
     class Supersede < Trailblazer::Operation
       step :set_primary_key

--- a/app/models/daily_update.rb
+++ b/app/models/daily_update.rb
@@ -1,0 +1,13 @@
+class DailyUpdate < ApplicationRecord
+  def model_to_update
+    model_name_to_update.camelize.constantize
+  end
+
+  def logger_for_import
+    Logger.new logger_file_path.to_s
+  end
+
+  def logger_file_path
+    Rails.root.join 'log', "daily_update_#{model_name_to_update}.log"
+  end
+end

--- a/db/migrate/20200119132507_create_daily_updates.rb
+++ b/db/migrate/20200119132507_create_daily_updates.rb
@@ -1,0 +1,12 @@
+class CreateDailyUpdates < ActiveRecord::Migration[5.0]
+  def change
+    create_table :daily_updates do |t|
+      t.string :status
+      t.string :model_name_to_update
+      t.datetime :from
+      t.datetime :to
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -30,20 +30,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
---
--- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
-
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -58,6 +44,41 @@ CREATE TABLE public.ar_internal_metadata (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
+
+
+--
+-- Name: daily_updates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.daily_updates (
+    id integer NOT NULL,
+    status character varying,
+    model_name_to_update character varying,
+    "from" timestamp without time zone,
+    "to" timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: daily_updates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.daily_updates_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: daily_updates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.daily_updates_id_seq OWNED BY public.daily_updates.id;
 
 
 --
@@ -555,6 +576,13 @@ ALTER SEQUENCE public.unites_legales_tmp_id_seq OWNED BY public.unites_legales_t
 
 
 --
+-- Name: daily_updates id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.daily_updates ALTER COLUMN id SET DEFAULT nextval('public.daily_updates_id_seq'::regclass);
+
+
+--
 -- Name: etablissements id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -602,6 +630,14 @@ ALTER TABLE ONLY public.unites_legales_tmp ALTER COLUMN id SET DEFAULT nextval('
 
 ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: daily_updates daily_updates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.daily_updates
+    ADD CONSTRAINT daily_updates_pkey PRIMARY KEY (id);
 
 
 --
@@ -779,6 +815,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190619121622'),
 ('20190703100825'),
 ('20191126124448'),
-('20191126124456');
+('20191126124456'),
+('20200119132507');
 
 

--- a/spec/concepts/daily_update/operation/update_database_spec.rb
+++ b/spec/concepts/daily_update/operation/update_database_spec.rb
@@ -5,22 +5,52 @@ describe DailyUpdate::Operation::UpdateDatabase, :trb do
 
   let(:logger) { instance_spy Logger }
 
+  before { Timecop.freeze(Time.new(2020, 1, 19, 15, 0, 0)) }
+
   context 'when stock import is completed' do
     let!(:stock_unite_legale) { create :stock_unite_legale, :completed }
     let!(:stock_etablissement) { create :stock_etablissement, :completed }
 
     it { is_expected.to be_success }
 
+    its([:du_unite_legale]) { is_expected.to be_persisted }
+
     it 'schedules DailyUpdateJob for unite legale' do
-      expect { subject }
-        .to have_enqueued_job(DailyUpdateModelJob)
-        .with('unite_legale')
+      id = subject[:du_unite_legale].id
+      expect(DailyUpdateModelJob)
+        .to have_been_enqueued
+        .with(id)
+        .on_queue('sirene_api_test_auto_updates')
     end
 
+    it 'creates a valid unite legale daily update' do
+      du = subject[:du_unite_legale]
+      expect(du).to have_attributes(
+        model_name_to_update: 'unite_legale',
+        status: 'PENDING',
+        from: Time.new(2020, 1, 1),
+        to: Time.new(2020, 1, 19, 15, 0, 0)
+      )
+    end
+
+    its([:du_etablissement]) { is_expected.to be_persisted }
+
     it 'schedules DailyUpdateJob for etablissement' do
-      expect { subject }
-        .to have_enqueued_job(DailyUpdateModelJob)
-        .with('etablissement')
+      id = subject[:du_etablissement].id
+      expect(DailyUpdateModelJob)
+        .to have_been_enqueued
+        .with(id)
+        .on_queue('sirene_api_test_auto_updates')
+    end
+
+    it 'creates a valid etablissement daily update' do
+      du = subject[:du_etablissement]
+      expect(du).to have_attributes(
+        model_name_to_update: 'etablissement',
+        status: 'PENDING',
+        from: Time.new(2020, 1, 1),
+        to: Time.new(2020, 1, 19, 15, 0, 0)
+      )
     end
   end
 

--- a/spec/concepts/daily_update/operation/update_spec.rb
+++ b/spec/concepts/daily_update/operation/update_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 describe DailyUpdate::Operation::Update, :trb do
-  subject { described_class.call model: model, logger: logger }
+  subject do
+    described_class.call model: model, from: from, to: to, logger: logger
+  end
 
   let(:logger) { instance_spy Logger }
-
-  before { Timecop.freeze Time.zone.parse('2019-12-01 20:00:00') }
+  let(:from) { Time.new(2019, 12, 1) }
+  let(:to) { Time.new(2019, 12, 1, 20, 0, 0) }
 
   context 'when updating UniteLegale', vcr: { cassette_name: 'insee/siren_update_1st_december' } do
     let(:model) { UniteLegale }

--- a/spec/concepts/stock/operation/load_unite_legale_spec.rb
+++ b/spec/concepts/stock/operation/load_unite_legale_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe Stock::Operation::LoadUniteLegale, vcr: { cassette_name: 'data_gouv_sirene_july_OK' } do
   subject { described_class.call logger: logger }
 
+  before { Timecop.freeze(Time.new(2019, 7, 5)) }
+
   let(:logger) { instance_spy Logger }
   let(:expected_uri) { 'http://files.data.gouv.fr/insee-sirene/StockUniteLegale_utf8.zip' }
 
@@ -29,9 +31,7 @@ describe Stock::Operation::LoadUniteLegale, vcr: { cassette_name: 'data_gouv_sir
     end
 
     its([:remote_stock]) { is_expected.to be_persisted }
-    its([:remote_stock]) do
-      is_expected.to have_attributes(uri: expected_uri, status: 'PENDING', month: '07', year: '2019')
-    end
+    its([:remote_stock]) { is_expected.to have_attributes(uri: expected_uri, status: 'PENDING', month: '07', year: '2019') }
   end
 
   context 'when remote stock is not importable (current stock stuck)' do

--- a/spec/factories/daily_update.rb
+++ b/spec/factories/daily_update.rb
@@ -1,0 +1,31 @@
+FactoryBot.define do
+  factory :daily_update do
+    pending
+    from { Time.new(2020, 1, 1) }
+    to { Time.new(2020, 1, 19) }
+
+    trait :for_etablissement do
+      model_name_to_update { 'etablissement' }
+    end
+
+    trait :for_unite_legale do
+      model_name_to_update { 'unite_legale' }
+    end
+
+    trait :pending do
+      status { 'PENDING' }
+    end
+
+    trait :loading do
+      status { 'LOADING' }
+    end
+
+    trait :errored do
+      status { 'ERROR' }
+    end
+
+    trait :completed do
+      status { 'COMPLETED' }
+    end
+  end
+end

--- a/spec/jobs/daily_update_model_job_spec.rb
+++ b/spec/jobs/daily_update_model_job_spec.rb
@@ -54,7 +54,7 @@ describe DailyUpdateModelJob, :trb do
       expect(daily_update.status).to eq 'ERROR'
     end
 
-    it 'calls the update operation' do
+    it 'rollback the operation' do
       subject
       unites_legales = UniteLegale.where(siren: 'GHOST')
       expect(unites_legales).to be_empty

--- a/spec/models/daily_update_spec.rb
+++ b/spec/models/daily_update_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe DailyUpdate do
+  it { is_expected.to have_db_column(:id).of_type(:integer) }
+  it { is_expected.to have_db_column(:model_name_to_update).of_type(:string) }
+  it { is_expected.to have_db_column(:status).of_type(:string) }
+  it { is_expected.to have_db_column(:from).of_type(:datetime) }
+  it { is_expected.to have_db_column(:to).of_type(:datetime) }
+  it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+
+  describe '#model_to_update' do
+    context 'with unite legale' do
+      subject { described_class.new(model_name_to_update: 'unite_legale') }
+
+      its(:model_to_update) { is_expected.to be UniteLegale }
+      its(:logger_for_import) { is_expected.to be_a Logger }
+
+      it 'has a valid log filename' do
+        expect(Logger).to receive(:new)
+          .with(%r{log\/daily_update_unite_legale.log})
+        subject.logger_for_import
+      end
+    end
+
+    context 'with etablissement' do
+      subject { described_class.new(model_name_to_update: 'etablissement') }
+
+      its(:model_to_update) { is_expected.to be Etablissement }
+      its(:logger_for_import) { is_expected.to be_a Logger }
+
+      it 'has a valid log filename' do
+        expect(Logger).to receive(:new)
+          .with(%r{log\/daily_update_etablissement.log})
+        subject.logger_for_import
+      end
+    end
+  end
+end

--- a/spec/models/stock_spec.rb
+++ b/spec/models/stock_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Stock do
   it { is_expected.to have_db_column(:id).of_type(:integer) }
+  it { is_expected.to have_db_column(:type).of_type(:string) }
   it { is_expected.to have_db_column(:year).of_type(:string) }
   it { is_expected.to have_db_column(:month).of_type(:string) }
   it { is_expected.to have_db_column(:status).of_type(:string) }


### PR DESCRIPTION
Dans cette PR (closes #242) :
- on log en base l'état de l'import quotidien (https://github.com/etalab/sirene_as_api/pull/240#discussion_r361427803)
- le logger est mieux stub vu qu'il provient d'une autre classe (https://github.com/etalab/sirene_as_api/pull/240#discussion_r361427572)

je ne suis pas très fan du nom de colonne `model_name_to_update` :
- on en peut pas utiliser `model` ou `model_name` c'est réservé à ActiveRecord
- j'ai pensé à `related_model`, plus court mais moins clair 😕
- ou `associated_model`