### PR TITLE
Daily update refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ coverage/*
 
 # Ignore INSEE secrets
 /config/insee_secrets.yml
+
+\.idea/

--- a/app/concepts/daily_update/operation/update.rb
+++ b/app/concepts/daily_update/operation/update.rb
@@ -12,7 +12,7 @@ class DailyUpdate
         results.each do |item|
           DailyUpdate::Task::Supersede.call(
             model: daily_update.related_model,
-            primary_key: daily_update.primary_key,
+            business_key: daily_update.business_key,
             data: item,
             logger: logger
           )

--- a/app/concepts/daily_update/operation/update.rb
+++ b/app/concepts/daily_update/operation/update.rb
@@ -7,18 +7,19 @@ class DailyUpdate
       pass :log_supersede_starts
       step :supersede
 
-      def supersede(_, model:, results:, logger:, **)
+      def supersede(_, daily_update:, results:, logger:, **)
         results.each do |item|
           DailyUpdate::Task::Supersede.call(
-            model: model,
+            model: daily_update.related_model,
+            primary_key: daily_update.primary_key,
             data: item,
             logger: logger
           )
         end
       end
 
-      def log_update_period(_, from:, to:, logger:, **)
-        logger.info "Importing from #{from} to #{to}"
+      def log_update_period(_, daily_update:, logger:, **)
+        logger.info "Importing from #{daily_update.from} to #{daily_update.to}"
       end
 
       def log_supersede_starts(_, results:, logger:, **)

--- a/app/concepts/daily_update/operation/update.rb
+++ b/app/concepts/daily_update/operation/update.rb
@@ -6,6 +6,7 @@ class DailyUpdate
       step Nested Task::AdaptApiResults
       pass :log_supersede_starts
       step :supersede
+      pass :log_update_done
 
       def supersede(_, daily_update:, results:, logger:, **)
         results.each do |item|
@@ -24,6 +25,10 @@ class DailyUpdate
 
       def log_supersede_starts(_, results:, logger:, **)
         logger.info "Supersede starts ; #{results.size} update to perform"
+      end
+
+      def log_update_done(_, daily_update:, logger:, **)
+        logger.info "#{daily_update.related_model} updated until #{daily_update.to}"
       end
     end
   end

--- a/app/concepts/daily_update/operation/update_database.rb
+++ b/app/concepts/daily_update/operation/update_database.rb
@@ -14,8 +14,7 @@ class DailyUpdate
       end
 
       def daily_updates_unite_legale(ctx, from:, to:, **)
-        ctx[:du_unite_legale] = DailyUpdate.create(
-          model_name_to_update: 'unite_legale',
+        ctx[:du_unite_legale] = DailyUpdateUniteLegale.create(
           status: 'PENDING',
           from: from,
           to: to
@@ -23,8 +22,7 @@ class DailyUpdate
       end
 
       def daily_updates_etablissement(ctx, from:, to:, **)
-        ctx[:du_etablissement] = DailyUpdate.create(
-          model_name_to_update: 'etablissement',
+        ctx[:du_etablissement] = DailyUpdateEtablissement.create(
           status: 'PENDING',
           from: from,
           to: to

--- a/app/concepts/daily_update/operation/update_database.rb
+++ b/app/concepts/daily_update/operation/update_database.rb
@@ -9,7 +9,7 @@ class DailyUpdate
       step :update_etablissement
 
       def set_period_to_update(ctx, **)
-        ctx[:from] = Time.now.beginning_of_month
+        ctx[:from] = Time.zone.now.beginning_of_month
         ctx[:to]   = Time.zone.now
       end
 

--- a/app/concepts/daily_update/task/adapt_api_results.rb
+++ b/app/concepts/daily_update/task/adapt_api_results.rb
@@ -2,24 +2,14 @@ class DailyUpdate
   module Task
     class AdaptApiResults < Trailblazer::Operation
       pass :log_adapt_starts
-      step :set_adapter
       step :adapt_api_results
       fail :log_adapter_failed
       pass :log_adapt_done
 
-      def set_adapter(ctx, model:, **)
-        case model.name
-        when UniteLegale.name
-          ctx[:adapter] = DailyUpdate::Task::AdaptUniteLegale
-        when Etablissement.name
-          ctx[:adapter] = DailyUpdate::Task::AdaptEtablissement
-        end
-      end
-
-      def adapt_api_results(ctx, adapter:, api_results:, **)
+      def adapt_api_results(ctx, daily_update:, api_results:, **)
         ctx[:results] = []
         api_results.each do |result|
-          operation = adapter.call result: result
+          operation = daily_update.adapter_task.call result: result
 
           if operation.failure?
             ctx[:failing_item] = result

--- a/app/concepts/daily_update/task/supersede.rb
+++ b/app/concepts/daily_update/task/supersede.rb
@@ -1,21 +1,11 @@
 class DailyUpdate
   module Task
     class Supersede < Trailblazer::Operation
-      step :set_primary_key
-      step :find_primary_key
+      step :find_primary_key_value
       fail :log_primary_key_not_found
       step :supersede
 
-      def set_primary_key(ctx, model:, **)
-        case model.name
-        when UniteLegale.name
-          ctx[:primary_key] = :siren
-        when Etablissement.name
-          ctx[:primary_key] = :siret
-        end
-      end
-
-      def find_primary_key(ctx, primary_key:, data:, **)
+      def find_primary_key_value(ctx, primary_key:, data:, **)
         ctx[:primary_key_value] = data[primary_key]
       end
 
@@ -30,11 +20,11 @@ class DailyUpdate
           false
         end
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def log_primary_key_not_found(_, primary_key:, data:, logger:, **)
         logger.error "Supersede failed, primary key (#{primary_key}) not found in #{data}"
       end
-      # rubocop:enable Metrics/ParameterLists
     end
   end
 end

--- a/app/concepts/daily_update/task/supersede.rb
+++ b/app/concepts/daily_update/task/supersede.rb
@@ -1,17 +1,17 @@
 class DailyUpdate
   module Task
     class Supersede < Trailblazer::Operation
-      step :find_primary_key_value
-      fail :log_primary_key_not_found
+      step :find_business_key_value
+      fail :log_business_key_not_found
       step :supersede
 
-      def find_primary_key_value(ctx, primary_key:, data:, **)
-        ctx[:primary_key_value] = data[primary_key]
+      def find_business_key_value(ctx, business_key:, data:, **)
+        ctx[:business_key_value] = data[business_key]
       end
 
       # rubocop:disable Metrics/ParameterLists
-      def supersede(_, model:, primary_key:, primary_key_value:, data:, logger:, **)
-        entity = model.find_or_initialize_by("#{primary_key}": primary_key_value)
+      def supersede(_, model:, business_key:, business_key_value:, data:, logger:, **)
+        entity = model.find_or_initialize_by("#{business_key}": business_key_value)
 
         begin
           entity.update_attributes(data)
@@ -22,8 +22,8 @@ class DailyUpdate
       end
       # rubocop:enable Metrics/ParameterLists
 
-      def log_primary_key_not_found(_, primary_key:, data:, logger:, **)
-        logger.error "Supersede failed, primary key (#{primary_key}) not found in #{data}"
+      def log_business_key_not_found(_, business_key:, data:, logger:, **)
+        logger.error "Supersede failed, primary key (#{business_key}) not found in #{data}"
       end
     end
   end

--- a/app/concepts/insee/api_client.rb
+++ b/app/concepts/insee/api_client.rb
@@ -1,6 +1,8 @@
 class INSEE::ApiClient
   include ActiveModel::Model
-  attr_accessor :model, :cursor, :token, :from, :to
+  attr_accessor :daily_update, :cursor, :token
+  extend Forwardable
+  def_delegators :@daily_update, :from, :to, :related_model, :insee_resource_suffix
 
   # value limited by INSEE
   MAX_ELEMENTS_PER_CALL = 1_000
@@ -29,17 +31,9 @@ class INSEE::ApiClient
   end
 
   def build_url
-    uri = URI(base_url + resource_name)
+    uri = URI(base_url + insee_resource_suffix)
     uri.query = URI.encode_www_form(query_hash)
     uri
-  end
-
-  def resource_name
-    unite_legale? ? 'siren' : 'siret'
-  end
-
-  def unite_legale?
-    model == UniteLegale
   end
 
   def query_hash
@@ -54,6 +48,6 @@ class INSEE::ApiClient
     from_s = from.strftime TIME_FORMAT
     to_s   = to.strftime TIME_FORMAT
 
-    "dateDernierTraitement#{model.name}:[#{from_s} TO #{to_s}]"
+    "dateDernierTraitement#{related_model.name}:[#{from_s} TO #{to_s}]"
   end
 end

--- a/app/jobs/daily_update_model_job.rb
+++ b/app/jobs/daily_update_model_job.rb
@@ -22,9 +22,7 @@ class DailyUpdateModelJob < ApplicationJob
 
   def params
     {
-      model: daily_update.model_to_update,
-      from: daily_update.from,
-      to: daily_update.to,
+      daily_update: daily_update,
       logger: daily_update.logger_for_import
     }
   end

--- a/app/models/daily_update.rb
+++ b/app/models/daily_update.rb
@@ -1,6 +1,9 @@
 class DailyUpdate < ApplicationRecord
-  def model_to_update
-    model_name_to_update.camelize.constantize
+  def related_model_name
+    related_model
+      .name
+      .underscore
+      .to_sym
   end
 
   def logger_for_import
@@ -8,6 +11,6 @@ class DailyUpdate < ApplicationRecord
   end
 
   def logger_file_path
-    Rails.root.join 'log', "daily_update_#{model_name_to_update}.log"
+    Rails.root.join 'log', "daily_update_#{related_model_name}.log"
   end
 end

--- a/app/models/daily_update_etablissement.rb
+++ b/app/models/daily_update_etablissement.rb
@@ -2,4 +2,20 @@ class DailyUpdateEtablissement < DailyUpdate
   def related_model
     Etablissement
   end
+
+  def primary_key
+    :siret
+  end
+
+  def insee_results_body_key
+    :etablissements
+  end
+
+  def insee_resource_suffix
+    'siret/'
+  end
+
+  def adapter_task
+    DailyUpdate::Task::AdaptEtablissement
+  end
 end

--- a/app/models/daily_update_etablissement.rb
+++ b/app/models/daily_update_etablissement.rb
@@ -1,0 +1,5 @@
+class DailyUpdateEtablissement < DailyUpdate
+  def related_model
+    Etablissement
+  end
+end

--- a/app/models/daily_update_etablissement.rb
+++ b/app/models/daily_update_etablissement.rb
@@ -3,7 +3,7 @@ class DailyUpdateEtablissement < DailyUpdate
     Etablissement
   end
 
-  def primary_key
+  def business_key
     :siret
   end
 

--- a/app/models/daily_update_unite_legale.rb
+++ b/app/models/daily_update_unite_legale.rb
@@ -3,7 +3,7 @@ class DailyUpdateUniteLegale < DailyUpdate
     UniteLegale
   end
 
-  def primary_key
+  def business_key
     :siren
   end
 

--- a/app/models/daily_update_unite_legale.rb
+++ b/app/models/daily_update_unite_legale.rb
@@ -1,0 +1,5 @@
+class DailyUpdateUniteLegale < DailyUpdate
+  def related_model
+    UniteLegale
+  end
+end

--- a/app/models/daily_update_unite_legale.rb
+++ b/app/models/daily_update_unite_legale.rb
@@ -2,4 +2,20 @@ class DailyUpdateUniteLegale < DailyUpdate
   def related_model
     UniteLegale
   end
+
+  def primary_key
+    :siren
+  end
+
+  def insee_results_body_key
+    :unitesLegales
+  end
+
+  def insee_resource_suffix
+    'siren/'
+  end
+
+  def adapter_task
+    DailyUpdate::Task::AdaptUniteLegale
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ Bundler.require(*Rails.groups)
 
 module SireneAsAPI
   class Application < Rails::Application
+    config.time_zone = 'Europe/Paris'
     config.api_only = true
     config.active_record.schema_format = :sql
 

--- a/db/migrate/20200127073524_add_sti_type_to_daily_updates.rb
+++ b/db/migrate/20200127073524_add_sti_type_to_daily_updates.rb
@@ -1,0 +1,5 @@
+class AddStiTypeToDailyUpdates < ActiveRecord::Migration[5.0]
+  def change
+    add_column :daily_updates, :type, :string
+  end
+end

--- a/db/migrate/20200127074730_remove_model_name_to_daily_updates.rb
+++ b/db/migrate/20200127074730_remove_model_name_to_daily_updates.rb
@@ -1,0 +1,5 @@
+class RemoveModelNameToDailyUpdates < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :daily_updates, :model_name_to_update
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -53,11 +53,11 @@ CREATE TABLE public.ar_internal_metadata (
 CREATE TABLE public.daily_updates (
     id integer NOT NULL,
     status character varying,
-    model_name_to_update character varying,
     "from" timestamp without time zone,
     "to" timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    type character varying
 );
 
 
@@ -816,6 +816,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190703100825'),
 ('20191126124448'),
 ('20191126124456'),
-('20200119132507');
+('20200119132507'),
+('20200127073524'),
+('20200127074730');
 
 

--- a/spec/concepts/daily_update/operation/update_database_spec.rb
+++ b/spec/concepts/daily_update/operation/update_database_spec.rb
@@ -4,8 +4,10 @@ describe DailyUpdate::Operation::UpdateDatabase, :trb do
   subject { described_class.call logger: logger }
 
   let(:logger) { instance_spy Logger }
+  let(:froze_time) { Time.zone.local(2020, 1, 19, 15, 0, 0) }
+  let(:beginning_of_month) { Time.zone.local(2020, 1, 1) }
 
-  before { Timecop.freeze(Time.new(2020, 1, 19, 15, 0, 0)) }
+  before { Timecop.freeze(froze_time) }
 
   context 'when stock import is completed' do
     let!(:stock_unite_legale) { create :stock_unite_legale, :completed }
@@ -28,8 +30,8 @@ describe DailyUpdate::Operation::UpdateDatabase, :trb do
       expect(du).to have_attributes(
         model_name_to_update: 'unite_legale',
         status: 'PENDING',
-        from: Time.new(2020, 1, 1),
-        to: Time.new(2020, 1, 19, 15, 0, 0)
+        from: beginning_of_month,
+        to: froze_time
       )
     end
 
@@ -48,8 +50,8 @@ describe DailyUpdate::Operation::UpdateDatabase, :trb do
       expect(du).to have_attributes(
         model_name_to_update: 'etablissement',
         status: 'PENDING',
-        from: Time.new(2020, 1, 1),
-        to: Time.new(2020, 1, 19, 15, 0, 0)
+        from: beginning_of_month,
+        to: froze_time
       )
     end
   end

--- a/spec/concepts/daily_update/operation/update_database_spec.rb
+++ b/spec/concepts/daily_update/operation/update_database_spec.rb
@@ -28,7 +28,7 @@ describe DailyUpdate::Operation::UpdateDatabase, :trb do
     it 'creates a valid unite legale daily update' do
       du = subject[:du_unite_legale]
       expect(du).to have_attributes(
-        model_name_to_update: 'unite_legale',
+        type: 'DailyUpdateUniteLegale',
         status: 'PENDING',
         from: beginning_of_month,
         to: froze_time
@@ -48,7 +48,7 @@ describe DailyUpdate::Operation::UpdateDatabase, :trb do
     it 'creates a valid etablissement daily update' do
       du = subject[:du_etablissement]
       expect(du).to have_attributes(
-        model_name_to_update: 'etablissement',
+        type: 'DailyUpdateEtablissement',
         status: 'PENDING',
         from: beginning_of_month,
         to: froze_time

--- a/spec/concepts/daily_update/operation/update_spec.rb
+++ b/spec/concepts/daily_update/operation/update_spec.rb
@@ -19,6 +19,12 @@ describe DailyUpdate::Operation::Update, :trb do
         .with(/Importing from 2019-12-01 00:00:00.+ to 2019-12-01 20:00:00.+/)
     end
 
+    it 'logs database updated' do
+      subject
+      expect(logger).to have_received(:info)
+        .with('UniteLegale updated until 2019-12-01 20:00:00 +0100')
+    end
+
     it 'fetch updates' do
       expect_to_call_nested_operation(INSEE::Operation::FetchUpdates)
       subject

--- a/spec/concepts/daily_update/operation/update_spec.rb
+++ b/spec/concepts/daily_update/operation/update_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
 describe DailyUpdate::Operation::Update, :trb do
-  subject do
-    described_class.call model: model, from: from, to: to, logger: logger
-  end
+  subject { described_class.call daily_update: daily_update, logger: logger }
 
+  let(:daily_update) { create :daily_update_unite_legale, from: from, to: to }
   let(:logger) { instance_spy Logger }
   let(:from) { Time.zone.local(2019, 12, 1) }
   let(:to) { Time.zone.local(2019, 12, 1, 20, 0, 0) }

--- a/spec/concepts/daily_update/operation/update_spec.rb
+++ b/spec/concepts/daily_update/operation/update_spec.rb
@@ -6,8 +6,8 @@ describe DailyUpdate::Operation::Update, :trb do
   end
 
   let(:logger) { instance_spy Logger }
-  let(:from) { Time.new(2019, 12, 1) }
-  let(:to) { Time.new(2019, 12, 1, 20, 0, 0) }
+  let(:from) { Time.zone.local(2019, 12, 1) }
+  let(:to) { Time.zone.local(2019, 12, 1, 20, 0, 0) }
 
   context 'when updating UniteLegale', vcr: { cassette_name: 'insee/siren_update_1st_december' } do
     let(:model) { UniteLegale }

--- a/spec/concepts/daily_update/task/adapt_api_results_spec.rb
+++ b/spec/concepts/daily_update/task/adapt_api_results_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe DailyUpdate::Task::AdaptApiResults, :trb do
-  subject { described_class.call model: model, api_results: api_results, logger: logger }
+  subject { described_class.call daily_update: daily_update, api_results: api_results, logger: logger }
 
   let(:logger) { instance_spy Logger }
   let(:api_results) { [item_1, item_2] }
@@ -16,7 +16,7 @@ describe DailyUpdate::Task::AdaptApiResults, :trb do
   end
 
   describe 'Etablissement' do
-    let(:model) { Etablissement }
+    let(:daily_update) { create :daily_update_etablissement }
     let(:fixture_path) { 'spec/fixtures/samples_insee/etablissement.json' }
 
     it { is_expected.to be_success }
@@ -34,7 +34,7 @@ describe DailyUpdate::Task::AdaptApiResults, :trb do
   end
 
   describe 'UniteLegale' do
-    let(:model) { UniteLegale }
+    let(:daily_update) { create :daily_update_unite_legale }
     let(:fixture_path) { 'spec/fixtures/samples_insee/unite_legale.json' }
 
     it { is_expected.to be_success }

--- a/spec/concepts/daily_update/task/supersede_spec.rb
+++ b/spec/concepts/daily_update/task/supersede_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 describe DailyUpdate::Task::Supersede do
-  subject { described_class.call model: model, primary_key: primary_key, data: data, logger: logger }
+  subject { described_class.call model: model, business_key: business_key, data: data, logger: logger }
 
   let(:logger) { instance_spy Logger }
 
   describe 'UniteLegale' do
     let(:model) { UniteLegale }
-    let(:primary_key) { :siren }
+    let(:business_key) { :siren }
 
     describe 'new unite legale created' do
       let(:new_siren) { '123456789' }
@@ -72,7 +72,7 @@ describe DailyUpdate::Task::Supersede do
 
   describe 'Etablissement' do
     let(:model) { Etablissement }
-    let(:primary_key) { :siret }
+    let(:business_key) { :siret }
     let(:data) { { siret: '12345678900000' } }
 
     it { is_expected.to be_success }

--- a/spec/concepts/daily_update/task/supersede_spec.rb
+++ b/spec/concepts/daily_update/task/supersede_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 describe DailyUpdate::Task::Supersede do
-  subject { described_class.call model: model, data: data, logger: logger }
+  subject { described_class.call model: model, primary_key: primary_key, data: data, logger: logger }
 
   let(:logger) { instance_spy Logger }
 
   describe 'UniteLegale' do
     let(:model) { UniteLegale }
+    let(:primary_key) { :siren }
 
     describe 'new unite legale created' do
       let(:new_siren) { '123456789' }
@@ -71,6 +72,7 @@ describe DailyUpdate::Task::Supersede do
 
   describe 'Etablissement' do
     let(:model) { Etablissement }
+    let(:primary_key) { :siret }
     let(:data) { { siret: '12345678900000' } }
 
     it { is_expected.to be_success }

--- a/spec/concepts/insee/api_client_spec.rb
+++ b/spec/concepts/insee/api_client_spec.rb
@@ -18,23 +18,23 @@ describe INSEE::ApiClient do
 
   context 'with valid params for Etablissement', vcr: { cassette_name: 'insee/siret_small_update_OK' } do
     let(:model) { Etablissement }
-    let(:from) { Time.new(2019, 11, 30) }
-    let(:to) { Time.new(2019, 12, 1) }
+    let(:from) { Time.zone.local(2019, 11, 30) }
+    let(:to) { Time.zone.local(2019, 12, 1) }
 
     it { is_expected.to be_a Net::HTTPOK }
   end
 
   describe 'UniteLegale' do
     let(:model) { UniteLegale }
-    let(:from) { Time.new(2019, 12, 8) }
-    let(:to) { Time.new(2019, 12, 9) }
+    let(:from) { Time.zone.local(2019, 12, 8) }
+    let(:to) { Time.zone.local(2019, 12, 9) }
 
     context 'with valid params for UniteLegale', vcr: { cassette_name: 'insee/siren_small_update_OK' } do
       it { is_expected.to be_a Net::HTTPOK }
     end
 
     context 'with invalid filter name', vcr: { cassette_name: 'insee/siren_updates_wrong_filter' } do
-      let(:from) { Time.new(2020, 1, 1) } # from > to
+      let(:from) { Time.zone.local(2020, 1, 1) } # from > to
 
       it { is_expected.to be_a Net::HTTPBadRequest }
     end

--- a/spec/concepts/insee/api_client_spec.rb
+++ b/spec/concepts/insee/api_client_spec.rb
@@ -5,11 +5,9 @@ describe INSEE::ApiClient do
 
   let(:params) do
     {
-      model: model,
+      daily_update: daily_update,
       cursor: '*',
-      token: token,
-      from: from,
-      to: to
+      token: token
     }
   end
 
@@ -17,7 +15,7 @@ describe INSEE::ApiClient do
   let(:token) { INSEE::Request::RenewToken.call(logger: logger)[:token] }
 
   context 'with valid params for Etablissement', vcr: { cassette_name: 'insee/siret_small_update_OK' } do
-    let(:model) { Etablissement }
+    let(:daily_update) { create :daily_update_etablissement, from: from, to: to }
     let(:from) { Time.zone.local(2019, 11, 30) }
     let(:to) { Time.zone.local(2019, 12, 1) }
 
@@ -25,7 +23,7 @@ describe INSEE::ApiClient do
   end
 
   describe 'UniteLegale' do
-    let(:model) { UniteLegale }
+    let(:daily_update) { create :daily_update_unite_legale, from: from, to: to }
     let(:from) { Time.zone.local(2019, 12, 8) }
     let(:to) { Time.zone.local(2019, 12, 9) }
 

--- a/spec/concepts/insee/operation/fetch_updates_spec.rb
+++ b/spec/concepts/insee/operation/fetch_updates_spec.rb
@@ -19,8 +19,8 @@ describe INSEE::Operation::FetchUpdates, :trb do
 
   describe 'with Etablissement', vcr: { cassette_name: 'insee/siret_small_update_OK' } do
     let(:model) { Etablissement }
-    let(:from) { Time.new(2019, 11, 30) }
-    let(:to) { Time.new(2019, 12, 1) }
+    let(:from) { Time.zone.local(2019, 11, 30) }
+    let(:to) { Time.zone.local(2019, 12, 1) }
 
     it { is_expected.to be_success }
 
@@ -41,8 +41,8 @@ describe INSEE::Operation::FetchUpdates, :trb do
 
   describe 'with UniteLegale', vcr: { cassette_name: 'insee/siren_small_update_OK' } do
     let(:model) { UniteLegale }
-    let(:from) { Time.new(2019, 12, 8) }
-    let(:to) { Time.new(2019, 12, 9) }
+    let(:from) { Time.zone.local(2019, 12, 8) }
+    let(:to) { Time.zone.local(2019, 12, 9) }
 
     it { is_expected.to be_success }
 
@@ -69,8 +69,8 @@ describe INSEE::Operation::FetchUpdates, :trb do
     end
 
     let(:model) { UniteLegale }
-    let(:from) { Time.new(2019, 12, 8) }
-    let(:to) { Time.new(2019, 12, 9) }
+    let(:from) { Time.zone.local(2019, 12, 8) }
+    let(:to) { Time.zone.local(2019, 12, 9) }
 
     it { is_expected.to be_failure }
 

--- a/spec/concepts/insee/operation/fetch_updates_spec.rb
+++ b/spec/concepts/insee/operation/fetch_updates_spec.rb
@@ -1,24 +1,16 @@
 require 'rails_helper'
 
 describe INSEE::Operation::FetchUpdates, :trb do
-  subject { described_class.call params }
+  subject { described_class.call daily_update: daily_update, logger: logger }
 
   let(:logger) { instance_spy Logger }
-  let(:params) do
-    {
-      model: model,
-      from: from,
-      to: to,
-      logger: logger
-    }
-  end
 
   before do
     stub_const('INSEE::ApiClient::MAX_ELEMENTS_PER_CALL', 20)
   end
 
   describe 'with Etablissement', vcr: { cassette_name: 'insee/siret_small_update_OK' } do
-    let(:model) { Etablissement }
+    let(:daily_update) { create :daily_update_etablissement, from: from, to: to }
     let(:from) { Time.zone.local(2019, 11, 30) }
     let(:to) { Time.zone.local(2019, 12, 1) }
 
@@ -40,7 +32,7 @@ describe INSEE::Operation::FetchUpdates, :trb do
   end
 
   describe 'with UniteLegale', vcr: { cassette_name: 'insee/siren_small_update_OK' } do
-    let(:model) { UniteLegale }
+    let(:daily_update) { create :daily_update_unite_legale, from: from, to: to }
     let(:from) { Time.zone.local(2019, 12, 8) }
     let(:to) { Time.zone.local(2019, 12, 9) }
 
@@ -68,7 +60,7 @@ describe INSEE::Operation::FetchUpdates, :trb do
         .and_return(trb_result_failure)
     end
 
-    let(:model) { UniteLegale }
+    let(:daily_update) { create :daily_update_unite_legale, from: from, to: to }
     let(:from) { Time.zone.local(2019, 12, 8) }
     let(:to) { Time.zone.local(2019, 12, 9) }
 

--- a/spec/concepts/insee/request/fetch_updates_with_cursor_spec.rb
+++ b/spec/concepts/insee/request/fetch_updates_with_cursor_spec.rb
@@ -5,9 +5,7 @@ describe INSEE::Request::FetchUpdatesWithCursor do
 
   let(:params) do
     {
-      model: model,
-      from: from,
-      to: to,
+      daily_update: daily_update,
       cursor: cursor,
       logger: logger
     }
@@ -17,7 +15,7 @@ describe INSEE::Request::FetchUpdatesWithCursor do
   let(:logger) { instance_spy Logger }
 
   context 'with valid params for Etablissement', vcr: { cassette_name: 'insee/siret_small_update_OK' } do
-    let(:model) { Etablissement }
+    let(:daily_update) { create :daily_update_etablissement, from: from, to: to }
     let(:from) { Time.zone.local(2019, 11, 30) }
     let(:to) { Time.zone.local(2019, 12, 1) }
 
@@ -28,12 +26,12 @@ describe INSEE::Request::FetchUpdatesWithCursor do
     it 'logs http get success' do
       subject
       expect(logger).to have_received(:info)
-        .with('49 etablissements retrieved, new cursor: AoEuODc5MTc4NTQ5MDAwMTc=')
+        .with('49 Etablissement retrieved, new cursor: AoEuODc5MTc4NTQ5MDAwMTc=')
     end
   end
 
   describe 'UniteLegale' do
-    let(:model) { UniteLegale }
+    let(:daily_update) { create :daily_update_unite_legale, from: from, to: to }
     let(:from) { Time.zone.local(2019, 12, 8) }
     let(:to) { Time.zone.local(2019, 12, 9) }
 
@@ -45,7 +43,7 @@ describe INSEE::Request::FetchUpdatesWithCursor do
       it 'logs http get success' do
         subject
         expect(logger).to have_received(:info)
-          .with('60 unitesLegales retrieved, new cursor: AoEpODc5MDc1NjM4')
+          .with('60 UniteLegale retrieved, new cursor: AoEpODc5MDc1NjM4')
       end
     end
 

--- a/spec/concepts/insee/request/fetch_updates_with_cursor_spec.rb
+++ b/spec/concepts/insee/request/fetch_updates_with_cursor_spec.rb
@@ -18,8 +18,8 @@ describe INSEE::Request::FetchUpdatesWithCursor do
 
   context 'with valid params for Etablissement', vcr: { cassette_name: 'insee/siret_small_update_OK' } do
     let(:model) { Etablissement }
-    let(:from) { Time.new(2019, 11, 30) }
-    let(:to) { Time.new(2019, 12, 1) }
+    let(:from) { Time.zone.local(2019, 11, 30) }
+    let(:to) { Time.zone.local(2019, 12, 1) }
 
     it { is_expected.to be_success }
 
@@ -34,8 +34,8 @@ describe INSEE::Request::FetchUpdatesWithCursor do
 
   describe 'UniteLegale' do
     let(:model) { UniteLegale }
-    let(:from) { Time.new(2019, 12, 8) }
-    let(:to) { Time.new(2019, 12, 9) }
+    let(:from) { Time.zone.local(2019, 12, 8) }
+    let(:to) { Time.zone.local(2019, 12, 9) }
 
     context 'with valid params for UniteLegale', vcr: { cassette_name: 'insee/siren_small_update_OK' } do
       it { is_expected.to be_success }
@@ -50,7 +50,7 @@ describe INSEE::Request::FetchUpdatesWithCursor do
     end
 
     context 'with invalid filter name', vcr: { cassette_name: 'insee/siren_updates_wrong_filter' } do
-      let(:from) { Time.new(2020, 1, 1) } # from > to
+      let(:from) { Time.zone.local(2020, 1, 1) } # from > to
 
       it { is_expected.to be_failure }
 

--- a/spec/concepts/stock/operation/load_unite_legale_spec.rb
+++ b/spec/concepts/stock/operation/load_unite_legale_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Stock::Operation::LoadUniteLegale, vcr: { cassette_name: 'data_gouv_sirene_july_OK' } do
   subject { described_class.call logger: logger }
 
-  before { Timecop.freeze(Time.new(2019, 7, 5)) }
+  before { Timecop.freeze(Time.zone.local(2019, 7, 5)) }
 
   let(:logger) { instance_spy Logger }
   let(:expected_uri) { 'http://files.data.gouv.fr/insee-sirene/StockUniteLegale_utf8.zip' }

--- a/spec/factories/daily_update.rb
+++ b/spec/factories/daily_update.rb
@@ -4,14 +4,6 @@ FactoryBot.define do
     from { Time.new(2020, 1, 1) }
     to { Time.new(2020, 1, 19) }
 
-    trait :for_etablissement do
-      model_name_to_update { 'etablissement' }
-    end
-
-    trait :for_unite_legale do
-      model_name_to_update { 'unite_legale' }
-    end
-
     trait :pending do
       status { 'PENDING' }
     end
@@ -28,4 +20,7 @@ FactoryBot.define do
       status { 'COMPLETED' }
     end
   end
+
+  factory :daily_update_unite_legale, parent: :daily_update, class: DailyUpdateUniteLegale
+  factory :daily_update_etablissement, parent: :daily_update, class: DailyUpdateEtablissement
 end

--- a/spec/factories/daily_update.rb
+++ b/spec/factories/daily_update.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :daily_update do
     pending
-    from { Time.new(2020, 1, 1) }
-    to { Time.new(2020, 1, 19) }
+    from { Time.zone.local(2020, 1, 1) }
+    to { Time.zone.local(2020, 1, 19) }
 
     trait :pending do
       status { 'PENDING' }

--- a/spec/fixtures/vcr_cassettes/insee/siren_small_update_OK.yml
+++ b/spec/fixtures/vcr_cassettes/insee/siren_small_update_OK.yml
@@ -53,7 +53,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:15 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=*&nombre=20&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=*&nombre=20&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -95,9 +95,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=20&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=20&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=20&curseur=AoEpNTEwNjk0MjI3&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=20&curseur=AoEpNTEwNjk0MjI3&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8
@@ -221,7 +221,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:15 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=AoEpNTEwNjk0MjI3&nombre=20&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=AoEpNTEwNjk0MjI3&nombre=20&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -263,9 +263,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=20&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=20&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=20&curseur=AoEpODQ3OTkyMzY5&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=20&curseur=AoEpODQ3OTkyMzY5&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8
@@ -340,7 +340,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:16 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=AoEpODQ3OTkyMzY5&nombre=20&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=AoEpODQ3OTkyMzY5&nombre=20&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -382,9 +382,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=20&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=20&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=20&curseur=AoEpODc5MDc1NjM4&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=20&curseur=AoEpODc5MDc1NjM4&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8
@@ -455,7 +455,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:17 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=AoEpODc5MDc1NjM4&nombre=20&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=AoEpODc5MDc1NjM4&nombre=20&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -497,7 +497,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=20&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=20&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="first"
       Content-Type:
       - application/json;charset=utf-8
@@ -514,7 +514,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:17 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=*&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=*&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2019-12-08T00:00:00%20TO%202019-12-09T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -556,9 +556,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=1000&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=1000&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=1000&curseur=AoEpODc5MDc1NjM4&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=1000&curseur=AoEpODc5MDc1NjM4&q=dateDernierTraitementUniteLegale%3A%5B2019-12-08T00%3A00%3A00+TO+2019-12-09T00%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8

--- a/spec/fixtures/vcr_cassettes/insee/siren_update_1st_december.yml
+++ b/spec/fixtures/vcr_cassettes/insee/siren_update_1st_december.yml
@@ -53,7 +53,7 @@ http_interactions:
   recorded_at: Sun, 01 Dec 2019 18:00:00 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=*&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2019-12-01T00:00:00%20TO%202019-12-01T20:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=*&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2019-12-01T00:00:00%20TO%202019-12-01T20:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -95,9 +95,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=1000&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-01T00%3A00%3A00+TO+2019-12-01T20%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=1000&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-01T00%3A00%3A00+TO+2019-12-01T20%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=1000&curseur=AoEpODc4MDkzODcx&q=dateDernierTraitementUniteLegale%3A%5B2019-12-01T00%3A00%3A00+TO+2019-12-01T20%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=1000&curseur=AoEpODc4MDkzODcx&q=dateDernierTraitementUniteLegale%3A%5B2019-12-01T00%3A00%3A00+TO+2019-12-01T20%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8
@@ -175,7 +175,7 @@ http_interactions:
   recorded_at: Sun, 01 Dec 2019 18:00:00 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=AoEpODc4MDkzODcx&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2019-12-01T00:00:00%20TO%202019-12-01T20:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=AoEpODc4MDkzODcx&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2019-12-01T00:00:00%20TO%202019-12-01T20:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -217,7 +217,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siren?nombre=1000&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-01T00%3A00%3A00+TO+2019-12-01T20%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siren/?nombre=1000&curseur=*&q=dateDernierTraitementUniteLegale%3A%5B2019-12-01T00%3A00%3A00+TO+2019-12-01T20%3A00%3A00%5D>;
         rel="first"
       Content-Type:
       - application/json;charset=utf-8

--- a/spec/fixtures/vcr_cassettes/insee/siren_updates_wrong_filter.yml
+++ b/spec/fixtures/vcr_cassettes/insee/siren_updates_wrong_filter.yml
@@ -53,7 +53,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 11:14:43 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=*&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2020-01-01T00:00:00%20TO%202019-12-04T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=*&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2020-01-01T00:00:00%20TO%202019-12-04T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -111,7 +111,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 11:14:43 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siren?curseur=*&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2020-01-01T00:00:00%20TO%202019-12-09T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siren/?curseur=*&nombre=1000&q=dateDernierTraitementUniteLegale:%5B2020-01-01T00:00:00%20TO%202019-12-09T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/insee/siret_small_update_OK.yml
+++ b/spec/fixtures/vcr_cassettes/insee/siret_small_update_OK.yml
@@ -53,7 +53,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:11 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siret?curseur=*&nombre=20&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siret/?curseur=*&nombre=20&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -95,9 +95,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=20&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=20&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=20&curseur=AoEuODM4NTA2NzIzMDAwMTc=&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=20&curseur=AoEuODM4NTA2NzIzMDAwMTc=&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8
@@ -197,7 +197,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:12 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siret?curseur=AoEuODM4NTA2NzIzMDAwMTc=&nombre=20&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siret/?curseur=AoEuODM4NTA2NzIzMDAwMTc=&nombre=20&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -239,9 +239,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=20&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=20&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=20&curseur=AoEuODUyMTIxNDkwMDAwMTk=&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=20&curseur=AoEuODUyMTIxNDkwMDAwMTk=&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8
@@ -343,7 +343,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:13 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siret?curseur=AoEuODUyMTIxNDkwMDAwMTk=&nombre=20&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siret/?curseur=AoEuODUyMTIxNDkwMDAwMTk=&nombre=20&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -385,9 +385,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=20&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=20&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=20&curseur=AoEuODc5MTc4NTQ5MDAwMTc=&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=20&curseur=AoEuODc5MTc4NTQ5MDAwMTc=&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8
@@ -468,7 +468,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:14 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siret?curseur=AoEuODc5MTc4NTQ5MDAwMTc=&nombre=20&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siret/?curseur=AoEuODc5MTc4NTQ5MDAwMTc=&nombre=20&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -510,7 +510,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=20&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=20&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="first"
       Content-Type:
       - application/json;charset=utf-8
@@ -527,7 +527,7 @@ http_interactions:
   recorded_at: Wed, 11 Dec 2019 12:32:14 GMT
 - request:
     method: get
-    uri: https://api.insee.fr/entreprises/sirene/V3/siret?curseur=*&nombre=1000&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
+    uri: https://api.insee.fr/entreprises/sirene/V3/siret/?curseur=*&nombre=1000&q=dateDernierTraitementEtablissement:%5B2019-11-30T00:00:00%20TO%202019-12-01T00:00:00%5D
     body:
       encoding: US-ASCII
       string: ''
@@ -569,9 +569,9 @@ http_interactions:
       Access-Control-Allow-Headers:
       - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
       Link:
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=1000&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=1000&curseur=*&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="first"
-      - <https://api.insee.fr/entreprises/sirene/siret?nombre=1000&curseur=AoEuODc5MTc4NTQ5MDAwMTc=&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
+      - <https://api.insee.fr/entreprises/sirene/siret/?nombre=1000&curseur=AoEuODc5MTc4NTQ5MDAwMTc=&q=dateDernierTraitementEtablissement%3A%5B2019-11-30T00%3A00%3A00+TO+2019-12-01T00%3A00%3A00%5D>;
         rel="next"
       Content-Type:
       - application/json;charset=utf-8

--- a/spec/jobs/daily_update_model_job_spec.rb
+++ b/spec/jobs/daily_update_model_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe DailyUpdateModelJob, :trb do
   subject { described_class.perform_now daily_update.id }
 
-  let(:daily_update) { create :daily_update, :for_unite_legale }
+  let(:daily_update) { create :daily_update_unite_legale }
   let(:import_logger) { instance_spy Logger }
 
   before do

--- a/spec/jobs/daily_update_model_job_spec.rb
+++ b/spec/jobs/daily_update_model_job_spec.rb
@@ -28,12 +28,7 @@ describe DailyUpdateModelJob, :trb do
     it 'calls the update operation' do
       expect(DailyUpdate::Operation::Update)
         .to receive(:call)
-        .with(
-          model: UniteLegale,
-          from: daily_update.from,
-          to: daily_update.to,
-          logger: import_logger
-        )
+        .with(daily_update: daily_update, logger: import_logger)
       subject
     end
   end

--- a/spec/models/daily_update_etablissement_spec.rb
+++ b/spec/models/daily_update_etablissement_spec.rb
@@ -4,7 +4,7 @@ describe DailyUpdateEtablissement do
   subject { build :daily_update_etablissement }
 
   its(:related_model) { is_expected.to be Etablissement }
-  its(:primary_key) { is_expected.to eq :siret }
+  its(:business_key) { is_expected.to eq :siret }
   its(:insee_results_body_key) { is_expected.to eq :etablissements }
   its(:adapter_task) { is_expected.to be DailyUpdate::Task::AdaptEtablissement }
   its(:insee_resource_suffix) { is_expected.to eq 'siret/' }

--- a/spec/models/daily_update_etablissement_spec.rb
+++ b/spec/models/daily_update_etablissement_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe DailyUpdateEtablissement do
+  subject { build :daily_update_etablissement }
+
+  its(:related_model) { is_expected.to be Etablissement }
+  its(:related_model_name) { is_expected.to be :etablissement }
+  its(:logger_for_import) { is_expected.to be_a Logger }
+
+  it 'has a valid log filename' do
+    expect(Logger).to receive(:new)
+      .with(%r{log\/daily_update_etablissement.log})
+    subject.logger_for_import
+  end
+end

--- a/spec/models/daily_update_etablissement_spec.rb
+++ b/spec/models/daily_update_etablissement_spec.rb
@@ -4,6 +4,10 @@ describe DailyUpdateEtablissement do
   subject { build :daily_update_etablissement }
 
   its(:related_model) { is_expected.to be Etablissement }
+  its(:primary_key) { is_expected.to eq :siret }
+  its(:insee_results_body_key) { is_expected.to eq :etablissements }
+  its(:adapter_task) { is_expected.to be DailyUpdate::Task::AdaptEtablissement }
+  its(:insee_resource_suffix) { is_expected.to eq 'siret/' }
   its(:related_model_name) { is_expected.to be :etablissement }
   its(:logger_for_import) { is_expected.to be_a Logger }
 

--- a/spec/models/daily_update_spec.rb
+++ b/spec/models/daily_update_spec.rb
@@ -2,38 +2,10 @@ require 'rails_helper'
 
 describe DailyUpdate do
   it { is_expected.to have_db_column(:id).of_type(:integer) }
-  it { is_expected.to have_db_column(:model_name_to_update).of_type(:string) }
+  it { is_expected.to have_db_column(:type).of_type(:string) }
   it { is_expected.to have_db_column(:status).of_type(:string) }
   it { is_expected.to have_db_column(:from).of_type(:datetime) }
   it { is_expected.to have_db_column(:to).of_type(:datetime) }
   it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
-
-  describe '#model_to_update' do
-    context 'with unite legale' do
-      subject { described_class.new(model_name_to_update: 'unite_legale') }
-
-      its(:model_to_update) { is_expected.to be UniteLegale }
-      its(:logger_for_import) { is_expected.to be_a Logger }
-
-      it 'has a valid log filename' do
-        expect(Logger).to receive(:new)
-          .with(%r{log\/daily_update_unite_legale.log})
-        subject.logger_for_import
-      end
-    end
-
-    context 'with etablissement' do
-      subject { described_class.new(model_name_to_update: 'etablissement') }
-
-      its(:model_to_update) { is_expected.to be Etablissement }
-      its(:logger_for_import) { is_expected.to be_a Logger }
-
-      it 'has a valid log filename' do
-        expect(Logger).to receive(:new)
-          .with(%r{log\/daily_update_etablissement.log})
-        subject.logger_for_import
-      end
-    end
-  end
 end

--- a/spec/models/daily_update_unite_legale_spec.rb
+++ b/spec/models/daily_update_unite_legale_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe DailyUpdateUniteLegale do
+  subject { build :daily_update_unite_legale }
+
+  its(:related_model) { is_expected.to be UniteLegale }
+  its(:related_model_name) { is_expected.to be :unite_legale }
+  its(:logger_for_import) { is_expected.to be_a Logger }
+
+  it 'has a valid log filename' do
+    expect(Logger).to receive(:new)
+      .with(%r{log\/daily_update_unite_legale.log})
+    subject.logger_for_import
+  end
+end

--- a/spec/models/daily_update_unite_legale_spec.rb
+++ b/spec/models/daily_update_unite_legale_spec.rb
@@ -4,6 +4,10 @@ describe DailyUpdateUniteLegale do
   subject { build :daily_update_unite_legale }
 
   its(:related_model) { is_expected.to be UniteLegale }
+  its(:primary_key) { is_expected.to eq :siren }
+  its(:insee_results_body_key) { is_expected.to eq :unitesLegales }
+  its(:insee_resource_suffix) { is_expected.to eq 'siren/' }
+  its(:adapter_task) { is_expected.to be DailyUpdate::Task::AdaptUniteLegale }
   its(:related_model_name) { is_expected.to be :unite_legale }
   its(:logger_for_import) { is_expected.to be_a Logger }
 

--- a/spec/models/daily_update_unite_legale_spec.rb
+++ b/spec/models/daily_update_unite_legale_spec.rb
@@ -4,7 +4,7 @@ describe DailyUpdateUniteLegale do
   subject { build :daily_update_unite_legale }
 
   its(:related_model) { is_expected.to be UniteLegale }
-  its(:primary_key) { is_expected.to eq :siren }
+  its(:business_key) { is_expected.to eq :siren }
   its(:insee_results_body_key) { is_expected.to eq :unitesLegales }
   its(:insee_resource_suffix) { is_expected.to eq 'siren/' }
   its(:adapter_task) { is_expected.to be DailyUpdate::Task::AdaptUniteLegale }


### PR DESCRIPTION
Refactor du `DailyUpdate` avec des classes filles (Rails STI), là où aujourd'hui il y des bout du type : 
```ruby
if model == UniteLegale
  'siren'
else
  'siret'
end
```
c'est remplacé par `daily_update.primary_key` par exemple.

Ça va déporter la responsabilité à chaque sous classe de savoir quelles sont les paramètres à transmettre aux opérations.

L'intégration des non diffusable se fera sur la même logique

Il y a aussi quelques autres légers changement les messages des commits devraient être explicites