### PR TITLE
API hide non-diffusables

### DIFF
--- a/app/serializers/api/v3/etablissement_serializer.rb
+++ b/app/serializers/api/v3/etablissement_serializer.rb
@@ -3,5 +3,24 @@ class API::V3::EtablissementSerializer < ApplicationSerializer
 
   attributes *all_fields
 
-  belongs_to :unite_legale
+  belongs_to :unite_legale, if: :with_association?
+
+  AUTHORIZED_FIELDS = %w[id siret nic siren statut_diffusion unite_legale date_dernier_traitement created_at updated_at].freeze
+
+  def initialize(object, options = {})
+    clean_unauthorized_fields(object) if object.statut_diffusion == 'N'
+    super
+  end
+
+  def with_association?
+    !instance_options[:without_association]
+  end
+
+  private
+
+  def clean_unauthorized_fields(object)
+    object.attributes.keys.each do |attribute|
+      object.send("#{attribute}=", nil) unless AUTHORIZED_FIELDS.include?(attribute)
+    end
+  end
 end

--- a/app/serializers/api/v3/unite_legale_serializer.rb
+++ b/app/serializers/api/v3/unite_legale_serializer.rb
@@ -7,7 +7,23 @@ class API::V3::UniteLegaleSerializer < ApplicationSerializer
 
   attribute :etablissement_siege
 
+  AUTHORIZED_FIELDS = %w[id siren statut_diffusion etablissements date_dernier_traitement created_at updated_at].freeze
+
+  def initialize(object, options = {})
+    clean_unauthorized_fields(object) if object.statut_diffusion == 'N'
+    super
+  end
+
   def etablissement_siege
-    object.etablissements.where(etablissement_siege: 'true').first
+    siege = object.etablissements.where(etablissement_siege: 'true').first
+    API::V3::EtablissementSerializer.new(siege, without_association: true).as_json.symbolize_keys unless siege.nil?
+  end
+
+  private
+
+  def clean_unauthorized_fields(object)
+    object.attributes.keys.each do |attribute|
+      object.send("#{attribute}=", nil) unless AUTHORIZED_FIELDS.include?(attribute)
+    end
   end
 end

--- a/spec/controllers/api/v3/etablissements_controller_spec.rb
+++ b/spec/controllers/api/v3/etablissements_controller_spec.rb
@@ -20,4 +20,49 @@ describe API::V3::EtablissementsController do
       expect(results[0]['unite_legale']).to include(JSON.parse(unite_legale.to_json))
     end
   end
+
+  context 'when asking for non diffusable' do
+    subject { response }
+
+    let(:attributes) { Etablissement.new.attributes.keys }
+    let(:mandatory_fields) { %w[id siren nic siret statut_diffusion date_dernier_traitement created_at updated_at] }
+    let(:mandatory_fields_matcher) { mandatory_fields.map { |f| [f, be_truthy] }.to_h }
+    let(:remaining_fields_matcher) do
+      remaining_fields = attributes - mandatory_fields
+      remaining_fields.map { |f| [f, be_nil] }.to_h
+    end
+
+    describe '#index', type: :request do
+      let!(:unites_legales) { create_list :unite_legale, 3, :non_diffusable }
+
+      before { get route.to_s }
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it 'has authorized fields' do
+        expect(subject.parsed_body[records]).to all include(mandatory_fields_matcher)
+      end
+
+      it 'has null in the remaining fields' do
+        expect(subject.parsed_body[records]).to all include(remaining_fields_matcher)
+      end
+    end
+
+    describe '#show', type: :request do
+      let!(:unite_legale) { create :unite_legale, :non_diffusable }
+      let(:siret) { unite_legale.etablissements.first.siret }
+
+      before { get "#{route}/#{siret}" }
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it 'has authorized fields' do
+        expect(subject.parsed_body[record]).to include(mandatory_fields_matcher)
+      end
+
+      it 'has null in the remaining fields' do
+        expect(subject.parsed_body[record]).to include(remaining_fields_matcher)
+      end
+    end
+  end
 end

--- a/spec/factories/etablissement_factory.rb
+++ b/spec/factories/etablissement_factory.rb
@@ -1,6 +1,13 @@
 FactoryBot.define do
   factory :etablissement do |_etablissement|
     sequence(:enseigne_1) { |n| "etablissement_#{n}" }
-    sequence(:siret) { |n| "0000000000000#{n}" }
+    sequence(:siren) { |n| "00000000#{n}" }
+    sequence(:nic) { |n| "0000#{n}" }
+    siret { siren + nic }
+    statut_diffusion { 'O' }
+
+    trait :non_diffusable do
+      statut_diffusion { 'N' }
+    end
   end
 end

--- a/spec/factories/unite_legale_factory.rb
+++ b/spec/factories/unite_legale_factory.rb
@@ -1,7 +1,23 @@
 FactoryBot.define do
   factory :unite_legale do
     sequence(:nom) { |n| "unite_legale_#{n}" }
+    sequence(:denomination) { |n| "denomination_#{n}" }
     sequence(:siren) { |n| "00000000#{n}" }
+    statut_diffusion { 'O' }
+
+    trait :non_diffusable do
+      statut_diffusion { 'N' }
+      date_dernier_traitement { '2016-11-30T14:31:01' }
+
+      after :create do |unite_legale|
+        create(:etablissement,
+               unite_legale: unite_legale,
+               siren: unite_legale.siren,
+               etablissement_siege: 'true',
+               date_dernier_traitement: '2016-11-30T14:31:01',
+               statut_diffusion: 'N')
+      end
+    end
 
     factory :unite_legale_with_2_etablissements do
       after(:create) do |unite_legale|

--- a/spec/serializers/etablissements_serializer_spec.rb
+++ b/spec/serializers/etablissements_serializer_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe API::V3::EtablissementSerializer do
+  subject { described_class.new(etab).as_json.deep_symbolize_keys }
+
+  context 'statut diffusion O' do
+    let(:unite_legale) { create :unite_legale }
+    let(:etab) { create :etablissement, unite_legale: unite_legale }
+
+    it 'serialize all fields normally' do
+      expect(subject).to include(
+        enseigne_1: be_a(String),
+        unite_legale: an_object_having_attributes(denomination: be_a(String))
+      )
+    end
+  end
+
+  context 'statut diffusion N' do
+    let(:etab) { create :etablissement, :non_diffusable }
+
+    it 'serialize everything to nil except white list fields' do
+      expect(subject).to include(
+        id: etab.id,
+        enseigne_1: nil,
+        siret: etab.siret,
+        nic: etab.nic,
+        siren: etab.siren,
+        statut_diffusion: 'N',
+        date_dernier_traitement: etab.date_dernier_traitement,
+        created_at: etab.created_at,
+        updated_at: etab.updated_at
+      )
+    end
+  end
+end

--- a/spec/serializers/unite_legale_serializer_spec.rb
+++ b/spec/serializers/unite_legale_serializer_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe API::V3::UniteLegaleSerializer do
+  subject { described_class.new(unite_legale).as_json.deep_symbolize_keys }
+
+  context 'statut diffusion O' do
+    let(:unite_legale) { create :unite_legale_with_2_etablissements }
+
+    it 'serialize all fields normally' do
+      expect(subject).to include(
+        denomination: be_a(String),
+        etablissement_siege: include(enseigne_1: be_a(String)),
+        etablissements: have(2).items
+      )
+    end
+  end
+
+  context 'statut diffusion N' do
+    let(:unite_legale) { create :unite_legale, :non_diffusable }
+
+    it 'serialize everything to nil except white list fields' do
+      expect(subject).to include(
+        id: unite_legale.id,
+        denomination: nil,
+        siren: unite_legale.siren,
+        statut_diffusion: 'N',
+        date_dernier_traitement: unite_legale.date_dernier_traitement,
+        etablissements: have(1).item,
+        etablissement_siege: include(enseigne_1: nil),
+        created_at: unite_legale.created_at,
+        updated_at: unite_legale.updated_at
+      )
+    end
+  end
+end


### PR DESCRIPTION
Quand un établissement ou une unité légale est non diffusable on met tous les champs à nul à l'exception de certains.

Le filtrage est fait dans l'initialize des Serializer.