### PR TITLE
Fix issue #221

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,24 @@
 FROM ruby:2.4
 
+RUN apt-get update -qq && apt-get install -y software-properties-common
+
+RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public |  apt-key add -
+
+RUN apt-add-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+
+RUN apt-get update -qq && apt-get install -y adoptopenjdk-8-hotspot
+
 RUN apt-get update -qq && apt-get install -y build-essential \
   libpq-dev \
   postgresql-client \
 # for Solr
-  openjdk-8-jre \
 # for nokogiri
   libxml2-dev \
   libxslt1-dev \
   # for cron scheduler job
   cron \
   vim
+RUN gem install bundler
 
 ENV APP_HOME /docker_build
 RUN mkdir $APP_HOME


### PR DESCRIPTION
Could not install openjdk on debian when building the sirene container. Install it from a third party repository instead, as recommended in https://stackoverflow.com/questions/57031649/how-to-install-openjdk-8-jdk-on-debian-10-buster