### PR TITLE
Remove transaction

### DIFF
--- a/app/concepts/stock/task/create_associations.rb
+++ b/app/concepts/stock/task/create_associations.rb
@@ -7,9 +7,7 @@ class Stock
       pass :log_associations_completed
 
       def create_associations(ctx, **)
-        ActiveRecord::Base.transaction do
-          execute_transaction(ctx)
-        end
+        execute_transaction(ctx)
       end
 
       def log_associations_starts(_, logger:, **)
@@ -30,7 +28,7 @@ class Stock
         ActiveRecord::Base.connection.execute(sql)
       rescue ActiveRecord::ActiveRecordError
         ctx[:error] = $ERROR_INFO
-        raise ActiveRecord::Rollback
+        false
       end
 
       def sql

--- a/spec/concepts/stock/task/create_associations_spec.rb
+++ b/spec/concepts/stock/task/create_associations_spec.rb
@@ -56,13 +56,5 @@ describe Stock::Task::CreateAssociations do
       subject
       expect(logger).to have_received(:error).with(/Association failed:/)
     end
-
-    it 'does not create association' do
-      subject
-      etab = Etablissement.new(
-        get_raw_data('etablissements_tmp').first
-      )
-      expect(etab.unite_legale_id).to be_nil
-    end
   end
 end


### PR DESCRIPTION
Lors de l'import des stocks on crée le lien entre les unités légales et les établissements dans les tables temporaires. Ceci était fait dans une transaction.

Pour une raison inconnue il semblerait que cela crée des locks sur les tables principales (non temp donc).

Détails:
Requêtes pour savoir quel PID génère les locks : 
```
select pid, usename, pg_blocking_pids(pid) as blocked_by, query as blocked_query
from pg_stat_activity
where cardinality(pg_blocking_pids(pid)) > 0;
```
Résultat:
![Capture d’écran de 2020-07-02 10-46-44](https://user-images.githubusercontent.com/5159985/86352122-fd93cb00-bc6d-11ea-81fe-66dc50c03800.png)

On voit bien que c'est le pid 21169 qui est : 
![Capture d’écran de 2020-07-02 10-46-55](https://user-images.githubusercontent.com/5159985/86352120-fcfb3480-bc6d-11ea-9477-d665a7cd9392.png)

Donc l'UPDATE sur `unites_legales_tmp` et `etablissments_tmp` génère un lock sur `unites_legales` et `etablissements`... wtf...

En supprimant le block de transaction de l'UPDATE cela semble résoudre le problème.