### PR TITLE
Fix encoding on CSV stock import

### DIFF
--- a/app/concepts/files/helper/csv_reader.rb
+++ b/app/concepts/files/helper/csv_reader.rb
@@ -32,7 +32,7 @@ module Files
           ],
           col_sep: ',',
           row_sep: "\n",
-          file_encoding: 'UTF-8'
+          force_utf8: true
         }
       end
       # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
Fix les erreurs d'encodage lors de l'import en base des stocks mensuels (cf le _libelle_commune_ https://entreprise.data.gouv.fr/api/sirene/v3/etablissements/20004470900018) 