### PR TITLE
Fix VAT number format

### DIFF
--- a/app/models/unite_legale.rb
+++ b/app/models/unite_legale.rb
@@ -16,4 +16,11 @@ class UniteLegale < ApplicationRecord
       send("#{attribute}=", nil) unless AUTHORIZED_FIELDS.include?(attribute)
     end
   end
+
+  def numero_tva_intra
+    tva_key =  (12 + 3 * (siren.to_i % 97)) % 97
+    padded_key = tva_key.to_s.rjust(2, '0')
+    tva_number = padded_key + siren.to_s
+    'FR' + tva_number
+  end
 end

--- a/app/serializers/api/v3/unite_legale_serializer.rb
+++ b/app/serializers/api/v3/unite_legale_serializer.rb
@@ -5,7 +5,7 @@ class API::V3::UniteLegaleSerializer < ApplicationSerializer
 
   has_many :etablissements
 
-  attribute :etablissement_siege
+  attributes :etablissement_siege, :numero_tva_intra
 
   def etablissement_siege
     # `order(nil)` remove the default ordering on id that slow down the request

--- a/spec/models/unite_legale_spec.rb
+++ b/spec/models/unite_legale_spec.rb
@@ -38,4 +38,15 @@ describe UniteLegale do
       end
     end
   end
+
+  describe '#numero_tva_intra' do
+    # The computed VAT validation key shall be two digits length
+    # and is padded with a leading 0 when needed.
+    # Here is an example where the validation key should be "09" instead of "9"
+    it 'is always 13 characters long' do
+      entreprise = build(:unite_legale, siren: '504019662')
+
+      expect(entreprise.numero_tva_intra).to eq('FR09504019662')
+    end
+  end
 end


### PR DESCRIPTION
Le numéro TVA fait 13 caractères et la clé de validation calculée doit être préfixée de zéro quand nécessaire.