### PR TITLE
Remove git reference for smarter_csv gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'active_model_serializers', '~> 0.10.0'
 
 # Import of data files
 gem 'activerecord-import'
-gem 'smarter_csv', git: 'https://github.com/tilo/smarter_csv.git', ref: '2b71026'
+gem 'smarter_csv'
 
 gem 'ruby-progressbar'
 # Gem progress_bar required for displaying progress in rake sunspot:reindex


### PR DESCRIPTION
Please do not pin a git-hash for smarter_csv - this version is far behind, and does not get bug-fixes or updates.

You might want to consider upgrading..

[Upgrade Wizard](https://tilo.github.io/smarter_csv/upgrade_wizard.html) [Upgrading.md](https://github.com/tilo/smarter_csv/blob/main/UPGRADING.md)